### PR TITLE
Melhora a tradução de "Abrigo Antiaéreo" para "Abrigo Antinuclear"

### DIFF
--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Expansion.xml
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Expansion.xml
@@ -212,7 +212,7 @@
 			<Text>Fornece 2 de [ICON_RES_ALUMINUM]Alumínio. Pode haver no máximo 5 desse edifício em seu império.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_BOMB_SHELTER_STRATEGY">
-			<Text>Abrigos Antiaéreos reduzem em 75% a perda de população nesta cidade, em caso de ataque nuclear. Esconda-se e sobreviva!</Text>
+			<Text>{TXT_KEY_BUILDING_BOMB_SHELTER[2]} reduzem em 75% a perda de população nesta cidade, em caso de ataque nuclear. Esconda-se e sobreviva!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_BOMB_SHELTER_HELP">
 			<Text>Reduz em 75% a perda de população em um ataque nuclear.</Text>

--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Buildings_Expansion.xml
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Buildings_Expansion.xml
@@ -75,7 +75,7 @@
 			<Plurality>1|2</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_BOMB_SHELTER">
-			<Text>Abrigo Antiaéreo|Abrigos Antiaéreos</Text>
+			<Text>Abrigo Antinuclear|Abrigos Antinucleares</Text>
 			<Gender>masculine|masculine</Gender>
 			<Plurality>1|2</Plurality>			
 		</Row>

--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Expansion.xml
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Expansion.xml
@@ -1520,7 +1520,7 @@
 			<Text>Combined arms is a military doctrine first adopted more than a thousand years ago, which involves the combination of different-but complimentary-unit types in an effort to improve the overall efficiency of the force as a whole. In ancient times, the combined arms tactic was utilized by many of the major powers, particularly the Greeks and Romans, who carefully coordinated light and heavy infantry, cavalry, and ranged weapons to create cohesive formations that played off each others' strengths and weaknesses. In the present day, the rise of aircraft-based weaponry has led to even more complex variations on the traditional concept of combined arms. Drone aircraft, satellite-guided missiles, and high-altitude bombers are just a few examples of the expanding toolset available to modern military commanders.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TECH_TELECOM_HELP">
-			<Text>Permite a construção do [COLOR_POSITIVE_TEXT]Submarino Nuclear[ENDCOLOR], uma Unidade Naval invisível à maioria das outras Unidades e capaz de carregar 2 Mísseis. Também permite a construção do [COLOR_POSITIVE_TEXT]Abrigo Antiaéreo[ENDCOLOR], que reduz significativamente a perda de população em um ataque nuclear.</Text>
+			<Text>Permite a construção do [COLOR_POSITIVE_TEXT]Submarino Nuclear[ENDCOLOR], uma Unidade Naval invisível à maioria das outras Unidades e capaz de carregar 2 Mísseis. Também permite a construção do [COLOR_POSITIVE_TEXT]{TXT_KEY_BUILDING_BOMB_SHELTER}[ENDCOLOR], que reduz significativamente a perda de população em um ataque nuclear.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TECH_TELECOM_QUOTE">
 			<Text>[NEWLINE][TAB][TAB]"Quanto mais elaboramos nossas formas de comunicação, menos nos comunicamos."[NEWLINE] - J.B. Priestly[NEWLINE][TAB]</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Inherited_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Inherited_Expansion2.xml
@@ -157,7 +157,7 @@
 			<Text>Fornece 2 de [ICON_RES_ALUMINUM]Alumínio. Pode haver no máximo 5 desse edifício em seu império.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_BOMB_SHELTER_STRATEGY">
-			<Text>Abrigos Antiaéreos reduzem em 75% a perda de população nesta cidade, em caso de ataque nuclear. Esconda-se e sobreviva!</Text>
+			<Text>{TXT_KEY_BUILDING_BOMB_SHELTER[2]} reduzem em 75% a perda de população nesta cidade, em caso de ataque nuclear. Esconda-se e sobreviva!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_BOMB_SHELTER_HELP">
 			<Text>Reduz em 75% a perda de população em um ataque nuclear.</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Buildings_Inherited_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Buildings_Inherited_Expansion2.xml
@@ -102,7 +102,7 @@
             <Plurality>1|2</Plurality>
         </Row>
         <Row Tag="TXT_KEY_BUILDING_BOMB_SHELTER">
-            <Text>Abrigo Antiaéreo|Abrigos Antiaéreo</Text>
+            <Text>Abrigo Antinuclear|Abrigos Antinucleares</Text>
             <Gender>masculine|masculine</Gender>
             <Plurality>1|2</Plurality>
         </Row>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Inherited_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Inherited_Expansion2.xml
@@ -442,7 +442,7 @@
 			<Text>Combined arms is a military doctrine first adopted more than a thousand years ago, which involves the combination of different-but complimentary-unit types in an effort to improve the overall efficiency of the force as a whole. In ancient times, the combined arms tactic was utilized by many of the major powers, particularly the Greeks and Romans, who carefully coordinated light and heavy infantry, cavalry, and ranged weapons to create cohesive formations that played off each others' strengths and weaknesses. In the present day, the rise of aircraft-based weaponry has led to even more complex variations on the traditional concept of combined arms. Drone aircraft, satellite-guided missiles, and high-altitude bombers are just a few examples of the expanding toolset available to modern military commanders.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TECH_TELECOM_HELP">
-			<Text>Permite a construção do [COLOR_POSITIVE_TEXT]Submarino Nuclear[ENDCOLOR], uma Unidade Naval invisível à maioria das outras Unidades e capaz de carregar 2 Mísseis. Também permite a construção do [COLOR_POSITIVE_TEXT]Abrigo Antiaéreo[ENDCOLOR], que reduz significativamente a perda de população em um ataque nuclear.</Text>
+			<Text>Permite a construção do [COLOR_POSITIVE_TEXT]Submarino Nuclear[ENDCOLOR], uma Unidade Naval invisível à maioria das outras Unidades e capaz de carregar 2 Mísseis. Também permite a construção do [COLOR_POSITIVE_TEXT]{TXT_KEY_BUILDING_BOMB_SHELTER}[ENDCOLOR], que reduz significativamente a perda de população em um ataque nuclear.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TECH_TELECOM_QUOTE">
 			<Text>[NEWLINE][TAB][TAB]"Quanto mais elaboramos nossas formas de comunicação, menos nos comunicamos."[NEWLINE] - J.B. Priestly[NEWLINE][TAB]</Text>


### PR DESCRIPTION
A função dessas edificações é proteger contra ataques nucleares, não aéreos.