### PR TITLE
Remove a opção de diálogos em português do menu

### DIFF
--- a/Assets/Gameplay/XML/NewText/Portuguese.xml
+++ b/Assets/Gameplay/XML/NewText/Portuguese.xml
@@ -9,13 +9,4 @@
             <PluralRule>2</PluralRule>
         </Row>
     </Languages>
-
-    <SpokenLanguages>
-        <Row>
-            <ID>10</ID>
-            <Type>pt_BR</Type>
-            <DisplayName>Português</DisplayName>
-            <Path>Portuguese</Path>
-        </Row>
-    </SpokenLanguages>
 </GameData>


### PR DESCRIPTION
O patch de tradução contém apenas o conteúdo escrito, não o falado.  Mas o menu de seleção de diálogos mostra a opção de "Português", que acaba não tendo nenhum efeito.
Fixes #25 