### PR TITLE
Revisão geral de artigos e pronomes de civilizações

### DIFF
--- a/Assets/DLC/DLC_01/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_MongolScenario.xml
+++ b/Assets/DLC/DLC_01/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_MongolScenario.xml
@@ -4,8 +4,8 @@
 	<Language_pt_BR>
 		<Row Tag="TXT_KEY_MONGOL_SCENARIO_CIV_SIAM_ADJECTIVE">
 			<Text>Jin|Jin</Text>
-			<Gender>masculine|feminine</Gender>
-			<Plurality>1|1</Plurality>			
+			<Gender>neuter</Gender>
+			<Plurality>1|2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_MONGOL_SCENARIO_CIV_SIAM_DESC">
 			<Text>Dinastia Jin</Text>
@@ -14,23 +14,23 @@
 		</Row>
 		<Row Tag="TXT_KEY_MONGOL_SCENARIO_CIV_SIAM_SHORT_DESC">
 			<Text>Jin</Text>
-			<Gender>feminine</Gender>
-			<Plurality>1</Plurality>			
+			<Gender>masculine</Gender>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_MONGOL_SCENARIO_CIV_GREECE_ADJECTIVE">
-			<Text>Bizante|Bizante</Text>
-			<Gender>masculine|feminine</Gender>
-			<Plurality>1|1</Plurality>			
+			<Text>Bizantino|Bizantina|Bizantinos|Bizantinas</Text>
+			<Gender>masculine|feminine|masculine|feminine</Gender>
+			<Plurality>1|1|2|2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_MONGOL_SCENARIO_CIV_GREECE_DESC">
-			<Text>Império Bizâncio</Text>
+			<Text>Império Bizantino</Text>
 			<Gender>masculine</Gender>
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_MONGOL_SCENARIO_CIV_GREECE_SHORT_DESC">
-			<Text>Bizante|Bizante</Text>
-			<Gender>masculine|feminine</Gender>
-			<Plurality>1|1</Plurality>			
+			<Text>Bizâncio</Text>
+			<Gender>masculine</Gender>
+			<Plurality>1</Plurality>
 		</Row>
 	</Language_pt_BR>
 </GameData>

--- a/Assets/DLC/DLC_02/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_NewWorldScenario.xml
+++ b/Assets/DLC/DLC_02/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_NewWorldScenario.xml
@@ -4,13 +4,19 @@
 	<!-- LocBuddy does not yet handle DLC scenarios so for now add the scenario text to the DLC package.-->
 	<Language_pt_BR>
 		<Row Tag="TXT_KEY_NEWWORLD_SCENARIO_CIV_JAPAN_ADJECTIVE">
-			<Text>Velho Mundo Europeu</Text>
+			<Text>Europeu do Velho Mundo|Europeia do Velho Mundo|Europeus do Velho Mundo|Europeias do Velho Mundo</Text>
+			<Gender>masculine|feminine|masculine|feminine</Gender>
+			<Plurality>1|1|2|2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_NEWWORLD_SCENARIO_CIV_JAPAN_DESC">
-			<Text>Velho Mundo Europeu</Text>
+			<Text>Europa do Velho Mundo</Text>
+			<Gender>feminine</Gender>
+			<Plurality>1</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_NEWWORLD_SCENARIO_CIV_JAPAN_SHORT_DESC">
 			<Text>Velho Mundo</Text>
+			<Gender>masculine</Gender>
+			<Plurality>1</Plurality>
 		</Row>
 	</Language_pt_BR>
 </GameData>

--- a/Assets/DLC/DLC_03/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_PolynesianScenario.xml
+++ b/Assets/DLC/DLC_03/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_PolynesianScenario.xml
@@ -15,7 +15,7 @@
 		</Row>
 		<Row Tag="TXT_KEY_POLYNESIAN_SCENARIO_CIV_POLYNESIA_SHORT_DESC">
 			<Text>Hiva</Text>
-      <Gender>masculine</Gender> 
+			<Gender>neuter:noart</Gender>
 			<Plurality>1</Plurality>									
 		</Row>
 		<Row Tag="TXT_KEY_POLYNESIAN_SCENARIO_CIV_AZTEC_ADJECTIVE">
@@ -30,7 +30,7 @@
 		</Row>
 		<Row Tag="TXT_KEY_POLYNESIAN_SCENARIO_CIV_AZTEC_SHORT_DESC">
 			<Text>Tonga</Text>
-      <Gender>masculine</Gender> 
+			<Gender>neuter:noart</Gender>
 			<Plurality>1</Plurality>									
 		</Row>
 		<Row Tag="TXT_KEY_POLYNESIAN_SCENARIO_CIV_INDIA_ADJECTIVE">
@@ -45,7 +45,7 @@
 		</Row>
 		<Row Tag="TXT_KEY_POLYNESIAN_SCENARIO_CIV_INDIA_SHORT_DESC">
 			<Text>Samoa</Text>
-      <Gender>feminine</Gender> 
+			<Gender>neuter:noart</Gender>
 			<Plurality>1</Plurality>									
 		</Row>
 		<Row Tag="TXT_KEY_POLYNESIAN_SCENARIO_CIV_IROQUOIS_ADJECTIVE">

--- a/Assets/DLC/DLC_06/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_WonderScenario.xml
+++ b/Assets/DLC/DLC_06/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_WonderScenario.xml
@@ -23,14 +23,14 @@
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_CIV_OTTOMAN_SHORT_DESC">
-			<Text>Os Hititas</Text>
+			<Text>Hititas</Text>
 			<Gender>masculine</Gender>
-			<Plurality>2</Plurality>			
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_CIV_OTTOMAN_ADJECTIVE">
-			<Text>Hitita|Hitita|Hititas|Hititas</Text>
-			<Gender>masculine|feminine|masculine|feminine</Gender>
-			<Plurality>1|1|2|2</Plurality>			
+			<Text>Hitita|Hititas</Text>
+			<Gender>neuter|neuter</Gender>
+			<Plurality>1|2</Plurality>
 		</Row>
 	</Language_pt_BR>
 </GameData>

--- a/Assets/DLC/DLC_06/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_WonderScenario.XML
+++ b/Assets/DLC/DLC_06/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_WonderScenario.XML
@@ -182,28 +182,28 @@
 			<Text>{@1_CivName} construindo em {@2_CityName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_BUILT_BY">
-			<Text>Construída {@1: gender masculine?{@1: plural 1?pelo; other?pelos;}; other?{@1: plural 1?pela; other?pelas;};} {@1_CivName} em {@2_CityName}</Text>
+			<Text>Construída {@1: gender *:noart?por; feminine?{@1: plural 2?pelas; other?pela;}; masculine?{@1: plural 2?pelos; other?pelo;}; other?por;} {@1_CivName} em {@2_CityName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_CAPTURED_BY">
-			<Text>[ICON_OCCUPIED]Capturada {@1: gender masculine?{@1: plural 1?pelo; other?pelos;}; other?{@1: plural 1?pela; other?pelas;};} {@1_CivName}</Text>
+			<Text>[ICON_OCCUPIED]Capturada {@1: gender *:noart?por; feminine?{@1: plural 2?pelas; other?pela;}; masculine?{@1: plural 2?pelos; other?pelo;}; other?por;} {@1_CivName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_UNLOCKED">
 			<Text>Liberada</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_UNLOCKED_BY">
-			<Text>Liberada {@1: gender masculine?{@1: plural 1?pelo; other?pelos;}; other?{@1: plural 1?pela; other?pelas;};} {@1_CivName}</Text>
+			<Text>Liberada {@1: gender *:noart?por; feminine?{@1: plural 2?pelas; other?pela;}; masculine?{@1: plural 2?pelos; other?pelo;}; other?por;} {@1_CivName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_LOCKED">
 			<Text>[ICON_LOCKED]Bloqueada</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_LOCKED_BY">
-			<Text>[ICON_LOCKED]Bloqueada {@1: gender masculine?{@1: plural 1?pelo; other?pelos;}; other?{@1: plural 1?pela; other?pelas;};} {@1_CivName}</Text>
+			<Text>[ICON_LOCKED]Bloqueada {@1: gender *:noart?por; feminine?{@1: plural 2?pelas; other?pela;}; masculine?{@1: plural 2?pelos; other?pelo;}; other?por;} {@1_CivName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_POPUP_WONDER_UNLOCKED">
 			<Text>Graças aos seus avanços, sua civilização liberou o poder para construir {@1: gender masculine?{@1: plural 1?o; other?os;}; other?{@1: plural 1?a; other?as;};} {@1_WonderName}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_POPUP_ORACLE_BUILT">
-			<Text>{@1_CivName} {@1: plural 1?completou; other?completaram;} o Oráculo! Para consultar o Oráculo, traga uma Grande Pessoa a uma distância de até {2_HexDist} {2: plural 1?hexágono; other?hexágonos;} de {@3_CityName}.</Text>
+			<Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_CivName} {@1: plural 1?completou; other?completaram;} o Oráculo! Para consultar o Oráculo, traga uma Grande Pessoa a uma distância de até {2_HexDist} {2: plural 1?hexágono; other?hexágonos;} de {@3_CityName}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_POPUP_ASK_CONSULT_ORACLE">
 			<Text>{@1_UnitName} {@1: plural 1?deverá; other?deverão;} consultar o Oráculo?[NEWLINE][NEWLINE]Isso durará {2_ConsultDuration} {2: plural 1?turno; other?turnos;}. Esta Grande Pessoa não poderá consultar o Oráculo novamente, mas não será consumida.</Text>
@@ -212,7 +212,7 @@
 			<Text>EXIBINDO: Informação revelada pela consulta ao Oráculo.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_POPUP_ORACLE_CONSULTED_BY">
-			<Text>{@1_CivName} {@1: plural 1?consultou; other?consultaram;} o Oráculo!</Text>
+			<Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_CivName} {@1: plural 1?consultou; other?consultaram;} o Oráculo!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WONDER_SCENARIO_POPUP_ORACLE_EXPIRED">
 			<Text>EXIBINDO: Informação conhecida por sua civilização.</Text>

--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Expansion.xml
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Expansion.xml
@@ -24,25 +24,25 @@
 		</Row>
 		<!-- Diplomacy-->
 		<Row Tag="TXT_KEY_MISC_MINOR_ALLIES_DECLARED_WAR_ON_YOU">
-			<Text>[COLOR_NEGATIVE_TEXT]As Cidades-Estado aliadas de {1_CivName:textkey} declararam guerra contra você![ENDCOLOR][NEWLINE]</Text>
+			<Text>[COLOR_NEGATIVE_TEXT]As Cidades-Estado aliadas {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} declararam guerra contra você![ENDCOLOR][NEWLINE]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_MINOR_ALLIES_DECLARED_WAR_ON_YOU_SUMMARY">
 			<Text>Cidades-Estado declararam guerra contra você!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_YOUR_MINOR_ALLIES_DECLARED_WAR">
-			<Text>Suas Cidades-Estados aliadas declararam guerra contra {1_CivName:textkey}:[NEWLINE]</Text>
+			<Text>Suas Cidades-Estados aliadas declararam guerra contra {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}:[NEWLINE]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_YOUR_MINOR_ALLIES_DECLARED_WAR_SUMMARY">
 			<Text>Suas Cidades-Estado aliadas declararam guerra!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_MADE_PEACE_WITH_MINOR_ALLIES">
-			<Text>{1_CivName:textkey} {1: plural 2?negociaram; other?negociou;} a paz com as Cidades-Estado:[NEWLINE]</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 2?negociaram; other?negociou;} a paz com as Cidades-Estado:[NEWLINE]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_MADE_PEACE_WITH_MINOR_ALLIES_SUMMARY">
-			<Text>{1_CivName:textkey} fez as pazes com Cidades-Estado.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} fez as pazes com Cidades-Estado.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_YOUR_MINOR_ALLIES_MADE_PEACE">
-			<Text>Suas Cidades-Estado aliadas fizeram as pazes com {1_CivName:textkey}:[NEWLINE]</Text>
+			<Text>Suas Cidades-Estado aliadas fizeram as pazes com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}:[NEWLINE]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_YOUR_MINOR_ALLIES_MADE_PEACE_SUMMARY">
 			<Text>Suas Cidades-Estado fizeram as pazes.</Text>
@@ -1710,7 +1710,7 @@
 			<Text>ESCOLHA UMA TECNOLOGIA GRATUITA</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CIV_RESURRECTED">
-			<Text>{1_PlayerName} conquistou {2_CityName} e restaurou a soberania {3_CivAdj[2]}. A chama de {4_CivName}, outrora apagada, queima novamente.</Text>
+			<Text>{1_PlayerName} conquistou {2_CityName} e restaurou a soberania {3_CivAdj[2]}. A chama {4: gender *:noart?de; feminine?{4: plural 2?das; other?da;}; masculine?{4: plural 2?dos; other?do;}; other?de;} {4_CivName}, outrora apagada, queima novamente.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CIV_RESURRECTED_SHORT">
 			<Text>{1_PlayerName} foi {1: gender feminine?libertada; other?libertado;} por {2_PlayerName}</Text>

--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_Scenarios_Expansion.xml
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_Scenarios_Expansion.xml
@@ -39,13 +39,13 @@
 			<Plurality>1</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_FOR_SCENARIO_CIV_PERSIA_SHORT_DESC">
-			<Text>Império Sassânida</Text>
+			<Text>Sassânidas</Text>
 			<Gender>masculine</Gender>
-			<Plurality>1</Plurality>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_FOR_SCENARIO_CIV_PERSIA_ADJECTIVE">
 			<Text>Sassânida|Sassânidas</Text>
-			<Gender>neuter:noart|neuter:noart</Gender>
+			<Gender>neuter</Gender>
 			<Plurality>1|2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_FOR_SCENARIO_CIV_FRANCE_DESC">
@@ -54,9 +54,9 @@
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_FOR_SCENARIO_CIV_FRANCE_SHORT_DESC">
-			<Text>Império Franco</Text>
+			<Text>Francos</Text>
 			<Gender>masculine</Gender>
-			<Plurality>1</Plurality>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_FOR_SCENARIO_CIV_FRANCE_ADJECTIVE">
 			<Text>Franco|Franca|Francos|Francas</Text>
@@ -69,9 +69,9 @@
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_FOR_SCENARIO_CIV_GERMANY_SHORT_DESC">
-			<Text>Reino Godo</Text>
-            <Gender>masculine</Gender>			
-			<Plurality>1</Plurality>
+			<Text>Godos</Text>
+			<Gender>masculine</Gender>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_FOR_SCENARIO_CIV_GERMANY_ADJECTIVE">
 			<Text>Godo|Goda|Godos|Godas</Text>
@@ -84,9 +84,9 @@
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_FOR_SCENARIO_CIV_SONGHAI_SHORT_DESC">
-			<Text>Império Vândalo</Text>
-            <Gender>masculine</Gender>			
-			<Plurality>1</Plurality>
+			<Text>Vândalos</Text>
+			<Gender>masculine</Gender>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_FOR_SCENARIO_CIV_SONGHAI_ADJECTIVE">
 			<Text>Vândalo|Vândala|Vândalos|Vândalas</Text>
@@ -101,9 +101,9 @@
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_GERMANY_SHORT_DESC">
-			<Text>Império Eruco</Text>
-            <Gender>masculine</Gender>			
-			<Plurality>1</Plurality>
+			<Text>Erucos</Text>
+			<Gender>masculine</Gender>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_GERMANY_ADJECTIVE">
 			<Text>Eruco|Eruca|Erucos|Erucas</Text>
@@ -131,9 +131,9 @@
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_ENGLAND_SHORT_DESC">
-			<Text>Império Pulias</Text>
-            <Gender>masculine</Gender>			
-			<Plurality>1</Plurality>			
+			<Text>Pulianos</Text>
+			<Gender>masculine</Gender>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_ENGLAND_ADJECTIVE">
 			<Text>Puliano|Puliana|Pulianos|Pulianas</Text>
@@ -146,9 +146,9 @@
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_SWEDEN_SHORT_DESC">
-			<Text>Império Vedria</Text>
-            <Gender>masculine</Gender>			
-			<Plurality>1</Plurality>			
+			<Text>Vedrianos</Text>
+			<Gender>masculine</Gender>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_SWEDEN_ADJECTIVE">
 			<Text>Vedriano|Vedriana|Vedrianos|Vedrianas</Text>
@@ -161,9 +161,9 @@
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_FRANCE_SHORT_DESC">
-			<Text>Dalmace</Text>
-			<Gender>feminine</Gender>
-			<Plurality>1</Plurality>			
+			<Text>Dalmacianos</Text>
+			<Gender>masculine</Gender>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_FRANCE_ADJECTIVE">
 			<Text>Dalmaciano|Dalmaciana|Dalmacianos|Dalmacianas</Text>
@@ -171,19 +171,19 @@
 			<Plurality>1|1|2|2</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_BARBARIAN_ADJECTIVE">
-			<Text>Ludite|Ludite|Ludites|Ludites</Text>
-			<Gender>masculine|feminine|masculine|feminine</Gender>
-			<Plurality>1|1|2|2</Plurality>
+			<Text>Ludita|Luditas</Text>
+			<Gender>neuter</Gender>
+			<Plurality>1|2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_BARBARIAN_DESC">
-			<Text>Horda Ludite</Text>
+			<Text>Horda Ludita</Text>
 			<Gender>feminine</Gender>
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_STEAMPUNK_SCENARIO_CIV_BARBARIAN_SHORT_DESC">
-			<Text>Horda Ludite</Text>
-            <Gender>masculine</Gender>			
-			<Plurality>1</Plurality>
+			<Text>Luditas</Text>
+			<Gender>masculine</Gender>
+			<Plurality>2</Plurality>
 		</Row>
 		
 		<!-- INTO THE RENAISSANCE -->
@@ -193,9 +193,9 @@
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_MEDIEVAL_SCENARIO_CIV_SONGHAI_SHORT_DESC">
-			<Text>Dinastia Aiúbida</Text>
-            <Gender>feminine</Gender>			
-			<Plurality>1</Plurality>
+			<Text>Aiúbidas</Text>
+			<Gender>masculine</Gender>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_MEDIEVAL_SCENARIO_CIV_SONGHAI_ADJECTIVE">
 			<Text>Aiúbido|Aiúbida|Aiúbidos|Aiúbidas</Text>
@@ -203,9 +203,9 @@
 			<Plurality>1|1|2|2</Plurality>            
 		</Row>
 		<Row Tag="TXT_KEY_MEDIEVAL_SCENARIO_CIV_ARABIA_SHORT_DESC">
-			<Text>Califado Almôada</Text>
-            <Gender>masculine</Gender>			
-			<Plurality>1</Plurality>
+			<Text>Almôadas</Text>
+			<Gender>masculine</Gender>
+			<Plurality>2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_MEDIEVAL_SCENARIO_CIV_ARABIA_DESC">
 			<Text>Califado Almôada</Text>            
@@ -213,13 +213,13 @@
 			<Plurality>1</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_MEDIEVAL_SCENARIO_CIV_ARABIA_ADJECTIVE">
-			<Text>Almôada|Almôada|Almôadas|Almôadas</Text>            
-			<Gender>masculine|feminine|masculine|feminine</Gender>
-			<Plurality>1|1|2|2</Plurality>			
+			<Text>Almôada|Almôadas</Text>
+			<Gender>neuter</Gender>
+			<Plurality>1|2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_MEDIEVAL_SCENARIO_CIV_OTTOMAN_SHORT_DESC">
-			<Text>Império Turco</Text>
-            <Gender>masculine</Gender>			
+			<Text>Turquia</Text>
+			<Gender>feminine</Gender>
 			<Plurality>1</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_MEDIEVAL_SCENARIO_CIV_OTTOMAN_DESC">

--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Jon_Expansion.xml
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Jon_Expansion.xml
@@ -37,7 +37,7 @@
 			<Text>Eles querem que você lhes dê um presente de ouro.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_QUEST_PLEDGE_TO_PROTECT">
-			<Text>Nós estamos cansados de sermos pressionados {1: plural 2?{1: gender feminine?pelas; masculine?pelos; other?por;}; other?{1: gender feminine?pela; masculine?pelo; other?por;};} {1_CivName:textkey}. Se você prometer publicamente nos proteger, talvez eles possam pensar duas vezes na próxima vez. Nós lhe recompensaremos pelo trabalho.</Text>
+			<Text>Nós estamos cansados de sermos pressionados {1: gender *:noart?por; feminine?{1: plural 2?pelas; other?pela;}; masculine?{1: plural 2?pelos; other?pelo;}; other?por;} {1_CivName:textkey}. Se você prometer publicamente nos proteger, talvez eles possam pensar duas vezes na próxima vez. Nós lhe recompensaremos pelo trabalho.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_QUEST_PLEDGE_TO_PROTECT_FORMAL">
 			<Text>Eles querem que você prometa proteção a eles.</Text>
@@ -334,7 +334,7 @@
 			<Text>Os líderes {2: gender *:noart?de; feminine?{2: plural 2?das; other?da;}; masculine?{2: plural 2?dos; other?do;}; other?de;} {2_MinorCivName:textkey} estão de olho na prosperidade das outras Cidades-Estado e querem que você os ajude a manter seus rivais em dificuldades. Se você exigir qualquer tipo de tributo {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_TargetName:textkey}, eles o recompensarão.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_BULLY_CITY_STATE">
-			<Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_MinorCivName:textkey} {2: plural 2?querem; other?quer;} {1_TargetName:textkey} {1: gender *:noart?intimidada; feminine?{1: plural 2?intimidadas; other?intimidada;}; masculine?{1: plural 2?intimidados; other?intimidado;}; other?intimidado;}.</Text>
+			<Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_MinorCivName:textkey} {2: plural 2?querem; other?quer;} {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_TargetName:textkey} {1: gender *:noart?intimidada; feminine?{1: plural 2?intimidadas; other?intimidada;}; masculine?{1: plural 2?intimidados; other?intimidado;}; other?intimidado;}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_COMPLETE_BULLY_CITY_STATE">
 			<Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_MinorCivName:textkey} {2: plural 2?gostaram; other?gostou;} de ver {1: gender masculine?seu rival; other?sua rival;}, {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_TargetName:textkey}, {1: plural 2?se contorcerem e abrirem mão; other?se contorcer e abrir mão;} de valiosos recursos. Sua [ICON_INFLUENCE]Influência com eles aumentou em [COLOR_POSITIVE_TEXT]{3_InfluenceReward}[ENDCOLOR]!</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Expansion2.xml
@@ -132,7 +132,7 @@
 			<Text>Primeira Cultura Influenciável</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CULTURE_VICTORY_SOMEONE_INFLUENTIAL_TT">
-			<Text>{1_CivName} {1_CivName: plural 1?é; other?são;} a primeira civilização a conseguir uma cultura que possui influência sobre outro jogador.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} {1_CivName: plural 1?é; other?são;} a primeira civilização a conseguir uma cultura que possui influência sobre outro jogador.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CULTURE_VICTORY_UNMET_INFLUENTIAL_TT">
 			<Text>Uma civilização desconhecida é a primeira civilização a conseguir uma cultura que possui influência sobre outro jogador.</Text>
@@ -156,7 +156,7 @@
 			<Text>Ameaça de Vitória Cultural</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CULTURE_VICTORY_WITHIN_ONE_TT">
-			<Text>{1_CivName} precisa ser influenciável sobre mais 1 civilização para obter uma Vitória Cultural!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} precisa infuenciar mais 1 civilização para obter uma Vitória Cultural!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CULTURE_VICTORY_WITHIN_TWO_ACTIVE_PLAYER">
 			<Text>Vitória Cultural ao Alcance</Text>
@@ -168,7 +168,7 @@
 			<Text>Vitória Cultural Disputada</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CULTURE_VICTORY_WITHIN_TWO_TT">
-			<Text>{1_CivName} precisa ser influenciável sobre mais 2 civilizações para obter uma Vitória Cultural.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} precisa influenciar mais 2 civilizações para obter uma Vitória Cultural.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_HELP_VENETIAN_GALLEASS">
 			<Text>Uma unidade naval brutalmente poderosa da Era Medieval, usada para tomar o controle dos mares com seu ataque a distância. Melhor no ataque e defesa que a {TXT_KEY_UNIT_GALLEASS} padrão que ela substitui, mas mais dispendiosa. Só pode ser construída por Veneza.</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Inherited_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Inherited_Expansion2.xml
@@ -24,25 +24,25 @@
 		</Row>
 		<!-- Diplomacy-->
 		<Row Tag="TXT_KEY_MISC_MINOR_ALLIES_DECLARED_WAR_ON_YOU">
-			<Text>[COLOR_NEGATIVE_TEXT]As Cidades-Estado aliadas de {1_CivName:textkey} declararam guerra contra você![ENDCOLOR][NEWLINE]</Text>
+			<Text>[COLOR_NEGATIVE_TEXT]As Cidades-Estado aliadas {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} declararam guerra contra você![ENDCOLOR][NEWLINE]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_MINOR_ALLIES_DECLARED_WAR_ON_YOU_SUMMARY">
 			<Text>Cidades-Estado declararam guerra contra você!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_YOUR_MINOR_ALLIES_DECLARED_WAR">
-			<Text>Suas Cidades-Estados aliadas declararam guerra contra {1_CivName:textkey}:[NEWLINE]</Text>
+			<Text>Suas Cidades-Estados aliadas declararam guerra contra {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}:[NEWLINE]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_YOUR_MINOR_ALLIES_DECLARED_WAR_SUMMARY">
 			<Text>Suas Cidades-Estado aliadas declararam guerra!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_MADE_PEACE_WITH_MINOR_ALLIES">
-			<Text>{1_CivName:textkey} {1: plural 2?negociaram; other?negociou;} a paz com as Cidades-Estado:[NEWLINE]</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 2?negociaram; other?negociou;} a paz com as Cidades-Estado:[NEWLINE]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_MADE_PEACE_WITH_MINOR_ALLIES_SUMMARY">
-			<Text>{1_CivName:textkey} fez as pazes com Cidades-Estado.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} fez as pazes com Cidades-Estado.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_YOUR_MINOR_ALLIES_MADE_PEACE">
-			<Text>Suas Cidades-Estado aliadas fizeram as pazes com {1_CivName:textkey}:[NEWLINE]</Text>
+			<Text>Suas Cidades-Estado aliadas fizeram as pazes com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}:[NEWLINE]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MISC_YOUR_MINOR_ALLIES_MADE_PEACE_SUMMARY">
 			<Text>Suas Cidades-Estado fizeram as pazes.</Text>
@@ -1547,7 +1547,7 @@
 			<Text>ESCOLHA UMA TECNOLOGIA GRATUITA</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CIV_RESURRECTED">
-			<Text>{1_PlayerName} conquistou {2_CityName} e restaurou a soberania {3_CivAdj[2]}. A chama de {4_CivName}, outrora apagada, queima novamente.</Text>
+			<Text>{1_PlayerName} conquistou {2_CityName} e restaurou a soberania {3_CivAdj[2]}. A chama {4: gender *:noart?de; feminine?{4: plural 2?das; other?da;}; masculine?{4: plural 2?dos; other?do;}; other?de;} {4_CivName}, outrora apagada, queima novamente.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CIV_RESURRECTED_SHORT">
 			<Text>{1_PlayerName} foi {1: gender feminine?libertada; other?libertado;} por {2_PlayerName}</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_ScrambleAfricaScenario.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilizations_ScrambleAfricaScenario.xml
@@ -4,9 +4,9 @@
     <Language_pt_BR>
         <!-- Civs and Leaders -->
         <Row Tag="TXT_KEY_SCRAMBLE_AFRICA_CIV_BRAZIL_ADJECTIVE">
-            <Text>Belga|Belga|Belgas|Belgas</Text>
+            <Text>Belga|Belgas</Text>
             <Gender>neuter</Gender>
-            <Plurality>1|1|2|2</Plurality>
+            <Plurality>1|2</Plurality>
         </Row>
         <Row Tag="TXT_KEY_SCRAMBLE_AFRICA_CIV_BRAZIL_DESC">
             <Text>Bélgica</Text>
@@ -34,17 +34,17 @@
             <Plurality>1</Plurality>
         </Row>
         <Row Tag="TXT_KEY_SCRAMBLE_AFRICA_CIV_AMERICA_ADJECTIVE">
-            <Text>Bôer|Bôer|Bôeres|Bôeres</Text>
+            <Text>Bôer|Bôeres</Text>
             <Gender>neuter</Gender>
-            <Plurality>1|1|2|2</Plurality>
+            <Plurality>1|2</Plurality>
         </Row>
         <Row Tag="TXT_KEY_SCRAMBLE_AFRICA_CIV_AMERICA_DESC">
-            <Text>Boer</Text>
+            <Text>Bôer</Text>
             <Gender>neuter</Gender>
             <Plurality>1</Plurality>
         </Row>
         <Row Tag="TXT_KEY_SCRAMBLE_AFRICA_CIV_AMERICA_SHORT_DESC">
-            <Text>Boer</Text>
+            <Text>Bôer</Text>
             <Gender>neuter</Gender>
             <Plurality>1</Plurality>
         </Row>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Expansion2.xml
@@ -1736,7 +1736,7 @@
 			<Text>O grande músico é um músico talentoso, e é muito importante para a vitória cultural.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_GREATMUSICIAN_ADV_QUEST">
-			<Text>O que é um Grande Músico?</Text>
+			<Text>O que é um grande músico?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_MUSICIAN_CREATEGW_HEADING4_TITLE">
 			<Text>Habilidade Especial: Grande Trabalho</Text>
@@ -1794,13 +1794,13 @@
 			<Text>Você pode aumentar em 50% a distância de suas rodadas em terra comerciais através da construção de Caravansaries nas cidades de origem. Eles também produzem um adicional de 2 [ICON_GOLD]Ouro quando se conectam a outra civilização. Os caravansários são disponibilizados por meio da pesquisa de passeios a cavalo.[NEWLINE][NEWLINE]Além disso, os portos aumentam em 50% a distância de suas rotas marítimas comerciais e geram mais 2 [ICON_GOLD]Ouro quando essas rotas se conectam a outra civilização. Eles são desbloqueados pesquisando a Bússola.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_EXTENDING_ADV_QUEST">
-			<Text>Como faço para ampliar o alcance das minhas Rotas de Comércio?</Text>
+			<Text>Como faço para ampliar o alcance das minhas rotas de comércio?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_BOOST_HEADING2_TITLE">
 			<Text>Renda Bônus de Edifícios</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_BOOST_HEADING2_BODY">
-			<Text>Existem vários edifícios e maravilhas que impulsionam sua renda na Rota Comercial.[NEWLINE][NEWLINE]Mercado: as rotas comerciais feitas em uma cidade com mercado geram um ouro extra de 2 [ICON_GOLD] para o proprietário da cidade e um extra 1 [ICON_GOLD] Ouro para o proprietário da rota comercial.[NEWLINE][NEWLINE]Companhia das Índias Orientais: a empresa da Índia Oriental A Maravilha Nacional gera um ouro extra de 4 [ICON_GOLD] para o proprietário da cidade em cada rota comercial estabelecida com aquela cidade e 2 [ICON_GOLD] Ouro para o proprietário da rota comercial.[NEWLINE][NEWLINE]Petra: A Petra Maravilha permite que você estabeleça uma rota comercial adicional e forneça uma Caravana na cidade gratuita na qual foi construída.[NEWLINE][NEWLINE]Colosso: O Colosso Maravilha faz com que as rotas comerciais feitas em sua cidade forneçam 2 [ICON_GOLD] de ouro extra para o proprietário da cidade e um ouro extra de [ICON_GOLD] para o proprietário da rota comercial. Ele também permite que você estabeleça uma rota comercial adicional e forneça um Navio de Carga gratuito na cidade em que foi construído.</Text>
+			<Text>Existem vários edifícios e maravilhas que impulsionam sua renda na Rota Comercial.[NEWLINE][NEWLINE]Mercado: as rotas comerciais feitas em uma cidade com mercado geram um ouro extra de 2 para o proprietário da cidade e um extra 1 Ouro para o proprietário da rota comercial.[NEWLINE][NEWLINE]Companhia das Índias Orientais: a empresa da Índia Oriental A Maravilha Nacional gera um ouro extra de 4 para o proprietário da cidade em cada rota comercial estabelecida com aquela cidade e 2 Ouro para o proprietário da rota comercial.[NEWLINE][NEWLINE]Petra: A Petra Maravilha permite que você estabeleça uma rota comercial adicional e forneça uma Caravana na cidade gratuita na qual foi construída.[NEWLINE][NEWLINE]Colosso: O Colosso Maravilha faz com que as rotas comerciais feitas em sua cidade forneçam 2 de ouro extra para o proprietário da cidade e um ouro extra de para o proprietário da rota comercial. Ele também permite que você estabeleça uma rota comercial adicional e forneça um Navio de Carga gratuito na cidade em que foi construído.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_BOOST_ADV_QUEST">
 			<Text>Quais outros Edifícios fornecem benefícios comerciais?</Text>
@@ -1809,19 +1809,19 @@
 			<Text>Impacto da guerra</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_WAR_HEADING2_BODY">
-			<Text>Quando uma Civilização declara guerra a outra, todas as Rotas Comerciais estabelecidas entre as duas civilizações são imediatamente destruídas.</Text>
+			<Text>Quando uma Civilização declara guerra a outra, todas as rotas comerciais estabelecidas entre as duas civilizações são imediatamente destruídas.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_WAR_ADV_QUEST">
-			<Text>A guerra afeta as minhas Rotas de Comércio?</Text>
+			<Text>A guerra afeta as minhas rotas de comércio?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_RELIGION_HEADING2_TITLE">
 			<Text>Rotas Comerciais e Religião</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_RELIGION_HEADING2_BODY">
-			<Text>Rotas Comerciais podem estender o alcance da propagação natural da religião. Por exemplo, uma cidade que tem uma religião majoritária pode exercer pressão até 10 hexágonos de distância. Com uma Rota Comercial, essa pressão pode ser estendida a uma cidade de destino que esteja além do intervalo normal de 10 hexágonos. Tenha em mente que isso acontece para rotas de comércio de entrada e saída.</Text>
+			<Text>Rotas comerciais podem estender o alcance da propagação natural da religião. Por exemplo, uma cidade que tem uma religião majoritária pode exercer pressão até 10 hexágonos de distância. Com uma rota comercial, essa pressão pode ser estendida a uma cidade de destino que esteja além do intervalo normal de 10 hexágonos. Tenha em mente que isso acontece para rotas de comércio de entrada e saída.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_RELIGION_ADV_QUEST">
-			<Text>As Rotas de Comércio podem espalhar a Religião?</Text>
+			<Text>As rotas de comércio podem espalhar a religião?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_SCIENCE_HEADING2_TITLE">
 			<Text>Rotas Comerciais e Ciência</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Expansion2.xml
@@ -1672,13 +1672,13 @@
 		</Row>
 		<!-- GREAT PEOPLE CONCEPTS -->
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_ARTIST_HEADING3_BODY">
-			<Text>Um artista especialista produz cultura e gera pontos para um Grande Artista. Os artistas são atribuídos ao único edifício com o slot especialista apropriado, a Guilda dos Artistas</Text>
+			<Text>Um artista especialista produz cultura e gera pontos para um Grande Artista. Artistas são designados ao único edifício com o espaço especializado apropriado, a Guilda de Artistas</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_WRITER_TITLE">
 			<Text>Escritor</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_WRITER_BODY">
-			<Text>Um escritor especialista produz cultura e gera pontos para um Grande Escritor. Escritores são atribuídos ao único edifício com o slot especialista apropriado, a Guilda dos Escritores.</Text>
+			<Text>Um escritor especialista produz cultura e gera pontos para um Grande Escritor. Escritores são designados ao único edifício com o espaço especializado apropriado, a Guilda de Escritores.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_WRITER_ADV_QUEST">
 			<Text>O que o escritor especialista faz?</Text>
@@ -1687,7 +1687,7 @@
 			<Text>Músico</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_MUSICIAN_BODY">
-			<Text>Um músico especialista produz cultura e gera pontos para um Grande Músico. Os músicos são designados para o único prédio com o espaço especializado apropriado, a Guilda dos Músicos.</Text>
+			<Text>Um músico especialista produz cultura e gera pontos para um Grande Músico. Músicos são designados ao único edifício com o espaço especializado apropriado, a Guilda de Músicos.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_MUSICIAN_ADV_QUEST">
 			<Text>O que o músico especialista faz?</Text>
@@ -1700,7 +1700,7 @@
 			<Text>O Grande Artista pode criar uma Grande Obra de Arte que é colocada na cidade mais próxima que possui um prédio apropriado com um espaço vazio (como o Palácio, um Museu ou uma Catedral). O Grande Artista é gasto quando usado dessa maneira.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_ART_CREATEGW_ADV_QUEST">
-			<Text>Como posso criar uma Grande Obra?</Text>
+			<Text>Como criar uma Grande Obra?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_GREATWRITER_HEADING3_TITLE">
 			<Text>Grande Escritor</Text>
@@ -1715,19 +1715,19 @@
 			<Text>Habilidade Especial: Grande Obra</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_WRITER_CREATEGW_HEADING4_BODY">
-			<Text>Um Grande Escritor pode criar uma Grande Obra de Escrita que é colocada na cidade mais próxima que tenha um prédio apropriado com um espaço vazio (como um Anfiteatro, Épico Nacional, Epopéia Heróica ou Biblioteca Real). O Grande Escritor é gasto quando usado dessa maneira.</Text>
+			<Text>Um Grande Escritor pode criar uma Grande Obra Literária que é colocada na cidade mais próxima que tenha um edifício apropriado com um espaço desocupado (como um Anfiteatro, uma Epopeia Nacional, uma Epopeia Heroica, ou uma Biblioteca Real). O Grande Escritor é gasto quando usado dessa forma.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_WRITER_CREATEGW_ADV_QUEST">
-			<Text>Como faço para criar uma Grande Obra?</Text>
+			<Text>Como criar uma Grande Obra?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_TREATISE_HEADING4_TITLE">
 			<Text>Habilidade Especial: Tratado político</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_TREATISE_HEADING4_BODY">
-			<Text>Um Grande Escritor pode escrever um Tratado Político, que concede ao jogador uma grande quantidade de Cultura. O Grande Escritor é gasto quando usado dessa maneira.</Text>
+			<Text>Um Grande Escritor pode escrever um Tratado Político, que concede ao jogador uma grande quantidade de Cultura. O Grande Escritor é gasto quando usado dessa forma.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_TREATISE_ADV_QUEST">
-			<Text>O que é um tratado político?</Text>
+			<Text>O que é um Tratado Político?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_GREATMUSICIAN_HEADING3_TITLE">
 			<Text>Grande Músico</Text>
@@ -1742,10 +1742,10 @@
 			<Text>Habilidade Especial: Grande Obra</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_MUSICIAN_CREATEGW_HEADING4_BODY">
-			<Text>A Grande Músico pode criar uma Grande Obra Musical que é colocada na cidade mais próxima que tenha um edifício apropriado com um lugar desocupado (como uma Casa de Ópera ou uma Torre de Difusão). O Grande Músico é gasto quando usado dessa forma.</Text>
+			<Text>A Grande Músico pode criar uma Grande Obra Musical que é colocada na cidade mais próxima que tenha um edifício apropriado com um espaço desocupado (como uma Casa de Ópera ou uma Torre de Difusão). O Grande Músico é gasto quando usado dessa forma.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_MUSICIAN_CREATEGW_ADV_QUEST">
-			<Text>Como eu crio uma Grande Obra?</Text>
+			<Text>Como criar uma Grande Obra?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_CONCERT_TOUR_HEADING4_TITLE">
 			<Text>Habilidade Especial: Turnê de Concertos</Text>
@@ -1791,7 +1791,7 @@
 			<Text>Estendendo o intervalo da rota comercial</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_EXTENDING_HEADING2_BODY">
-			<Text>Você pode aumentar em 50% a distância de suas rodadas em terra comerciais através da construção de Caravansaries nas cidades de origem. Eles também produzem um adicional de 2 Ouro quando se conectam a outra civilização. Os caravansários são disponibilizados por meio da pesquisa de passeios a cavalo.[NEWLINE][NEWLINE]Além disso, os portos aumentam em 50% a distância de suas rotas marítimas comerciais e geram mais 2 Ouro quando essas rotas se conectam a outra civilização. Eles são desbloqueados, pesquisando a Bússola.</Text>
+			<Text>Você pode aumentar em 50% a distância de suas rodadas em terra comerciais através da construção de Caravansaries nas cidades de origem. Eles também produzem um adicional de 2 [ICON_GOLD]Ouro quando se conectam a outra civilização. Os caravansários são disponibilizados por meio da pesquisa de passeios a cavalo.[NEWLINE][NEWLINE]Além disso, os portos aumentam em 50% a distância de suas rotas marítimas comerciais e geram mais 2 [ICON_GOLD]Ouro quando essas rotas se conectam a outra civilização. Eles são desbloqueados pesquisando a Bússola.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_EXTENDING_ADV_QUEST">
 			<Text>Como faço para ampliar o alcance das minhas rotas de comércio?</Text>
@@ -1800,7 +1800,7 @@
 			<Text>Renda Bônus de Edifícios</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_BOOST_HEADING2_BODY">
-			<Text>Existem vários edifícios e maravilhas que impulsionam sua renda na Rota Comercial.[NEWLINE][NEWLINE]Mercado: as rotas comerciais feitas em uma cidade com mercado geram um ouro extra de 2 para o proprietário da cidade e um extra 1 Ouro para o proprietário da rota comercial.[NEWLINE][NEWLINE]Companhia das Índias Orientais: a empresa da Índia Oriental A Maravilha Nacional gera um ouro extra de 4 para o proprietário da cidade em cada rota comercial estabelecida com aquela cidade e 2 Ouro para o proprietário da rota comercial.[NEWLINE][NEWLINE]Petra: A Petra Maravilha permite que você estabeleça uma rota comercial adicional e forneça uma Caravana na cidade gratuita na qual foi construída.[NEWLINE][NEWLINE]Colosso: O Colosso Maravilha faz com que as rotas comerciais feitas em sua cidade forneçam 2 de ouro extra para o proprietário da cidade e um ouro extra de para o proprietário da rota comercial. Ele também permite que você estabeleça uma rota comercial adicional e forneça um Navio de Carga gratuito na cidade em que foi construído.</Text>
+			<Text>Existem vários edifícios e maravilhas que impulsionam sua renda na Rota Comercial.[NEWLINE][NEWLINE]Mercado: as rotas comerciais feitas em uma cidade com mercado geram um ouro extra de 2 [ICON_GOLD] para o proprietário da cidade e um extra 1 [ICON_GOLD] Ouro para o proprietário da rota comercial [NEWLINE] [NEWLINE] Companhia das Índias Orientais: a empresa da Índia Oriental A Maravilha Nacional gera um ouro extra de 4 [ICON_GOLD] para o proprietário da cidade em cada rota comercial estabelecida com aquela cidade e 2 [ICON_GOLD] Ouro para o proprietário da rota comercial[NEWLINE][NEWLINE]Petra: A Petra Maravilha permite que você estabeleça uma rota comercial adicional e forneça uma Caravana na cidade gratuita na qual foi construída[NEWLINE][NEWLINE]Colosso: O Colosso Maravilha faz com que as rotas comerciais feitas em sua cidade forneçam 2 [ICON_GOLD] de ouro extra para o proprietário da cidade e um ouro extra de [ICON_GOLD] para o proprietário da rota comercial. Ele também permite que você estabeleça uma rota comercial adicional e forneça um Navio de Carga gratuito na cidade em que foi construído.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_BOOST_ADV_QUEST">
 			<Text>Quais outros Edifícios fornecem benefícios comerciais?</Text>
@@ -1809,7 +1809,7 @@
 			<Text>Impacto da guerra</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_WAR_HEADING2_BODY">
-			<Text>Quando uma Civilização declara guerra a outra, todas as rotas comerciais estabelecidas entre as duas civilizações são imediatamente destruídas.</Text>
+			<Text>Quando uma civilização declara guerra a outra, todas as rotas comerciais estabelecidas entre as duas civilizações são imediatamente destruídas.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_WAR_ADV_QUEST">
 			<Text>A guerra afeta as minhas rotas de comércio?</Text>
@@ -1998,7 +1998,7 @@
 			<Text>Você pode construir uma Guilda de Escritores!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ADVISOR_WRITERS_GUILD_BODY">
-			<Text>A Guilda de Escritores permite [COLOR_ADVISOR_HIGHLIGHT_TEXT]gerar Grandes Escritores[/COLOR] designando especialistas para ela. Um Grande Escritor é um novo tipo de Grande Pessoa que te permite criar [COLOR_ADVISOR_HIGHLIGHT_TEXT]Grandes Obras Literárias[/COLOR], essenciais para gerar [ICON_TOURISM] Turismo e vencer uma Vitória Cultural.</Text>
+			<Text>A Guilda de Escritores permite [COLOR_ADVISOR_HIGHLIGHT_TEXT]gerar Grandes Escritores[/COLOR] designando especialistas para ela. Um Grande Escritor é um novo tipo de Grande Pessoa que te permite criar [COLOR_ADVISOR_HIGHLIGHT_TEXT]Grandes Obras Literárias[/COLOR], essenciais para gerar [ICON_TOURISM]Turismo e vencer uma Vitória Cultural.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ADVISOR_ARTISTS_GUILD_DISPLAY">
 			<Text>Você pode construir uma Guilda de Artistas!</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Expansion2.xml
@@ -1739,7 +1739,7 @@
 			<Text>O que é um Grande Músico?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_MUSICIAN_CREATEGW_HEADING4_TITLE">
-			<Text>Habilidade Especial: Grande Obra</Text>
+			<Text>Habilidade Especial: Grande Trabalho</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SPECIALISTSANDGP_MUSICIAN_CREATEGW_HEADING4_BODY">
 			<Text>A Grande Músico pode criar uma Grande Obra Musical que é colocada na cidade mais próxima que tenha um edifício apropriado com um espaço desocupado (como uma Casa de Ópera ou uma Torre de Difusão). O Grande Músico é gasto quando usado dessa forma.</Text>
@@ -1794,13 +1794,13 @@
 			<Text>Você pode aumentar em 50% a distância de suas rodadas em terra comerciais através da construção de Caravansaries nas cidades de origem. Eles também produzem um adicional de 2 [ICON_GOLD]Ouro quando se conectam a outra civilização. Os caravansários são disponibilizados por meio da pesquisa de passeios a cavalo.[NEWLINE][NEWLINE]Além disso, os portos aumentam em 50% a distância de suas rotas marítimas comerciais e geram mais 2 [ICON_GOLD]Ouro quando essas rotas se conectam a outra civilização. Eles são desbloqueados pesquisando a Bússola.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_EXTENDING_ADV_QUEST">
-			<Text>Como faço para ampliar o alcance das minhas rotas de comércio?</Text>
+			<Text>Como faço para ampliar o alcance das minhas Rotas de Comércio?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_BOOST_HEADING2_TITLE">
 			<Text>Renda Bônus de Edifícios</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_BOOST_HEADING2_BODY">
-			<Text>Existem vários edifícios e maravilhas que impulsionam sua renda na Rota Comercial.[NEWLINE][NEWLINE]Mercado: as rotas comerciais feitas em uma cidade com mercado geram um ouro extra de 2 [ICON_GOLD] para o proprietário da cidade e um extra 1 [ICON_GOLD] Ouro para o proprietário da rota comercial [NEWLINE] [NEWLINE] Companhia das Índias Orientais: a empresa da Índia Oriental A Maravilha Nacional gera um ouro extra de 4 [ICON_GOLD] para o proprietário da cidade em cada rota comercial estabelecida com aquela cidade e 2 [ICON_GOLD] Ouro para o proprietário da rota comercial[NEWLINE][NEWLINE]Petra: A Petra Maravilha permite que você estabeleça uma rota comercial adicional e forneça uma Caravana na cidade gratuita na qual foi construída[NEWLINE][NEWLINE]Colosso: O Colosso Maravilha faz com que as rotas comerciais feitas em sua cidade forneçam 2 [ICON_GOLD] de ouro extra para o proprietário da cidade e um ouro extra de [ICON_GOLD] para o proprietário da rota comercial. Ele também permite que você estabeleça uma rota comercial adicional e forneça um Navio de Carga gratuito na cidade em que foi construído.</Text>
+			<Text>Existem vários edifícios e maravilhas que impulsionam sua renda na Rota Comercial.[NEWLINE][NEWLINE]Mercado: as rotas comerciais feitas em uma cidade com mercado geram um ouro extra de 2 [ICON_GOLD] para o proprietário da cidade e um extra 1 [ICON_GOLD] Ouro para o proprietário da rota comercial.[NEWLINE][NEWLINE]Companhia das Índias Orientais: a empresa da Índia Oriental A Maravilha Nacional gera um ouro extra de 4 [ICON_GOLD] para o proprietário da cidade em cada rota comercial estabelecida com aquela cidade e 2 [ICON_GOLD] Ouro para o proprietário da rota comercial.[NEWLINE][NEWLINE]Petra: A Petra Maravilha permite que você estabeleça uma rota comercial adicional e forneça uma Caravana na cidade gratuita na qual foi construída.[NEWLINE][NEWLINE]Colosso: O Colosso Maravilha faz com que as rotas comerciais feitas em sua cidade forneçam 2 [ICON_GOLD] de ouro extra para o proprietário da cidade e um ouro extra de [ICON_GOLD] para o proprietário da rota comercial. Ele também permite que você estabeleça uma rota comercial adicional e forneça um Navio de Carga gratuito na cidade em que foi construído.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_BOOST_ADV_QUEST">
 			<Text>Quais outros Edifícios fornecem benefícios comerciais?</Text>
@@ -1809,19 +1809,19 @@
 			<Text>Impacto da guerra</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_WAR_HEADING2_BODY">
-			<Text>Quando uma civilização declara guerra a outra, todas as rotas comerciais estabelecidas entre as duas civilizações são imediatamente destruídas.</Text>
+			<Text>Quando uma Civilização declara guerra a outra, todas as Rotas Comerciais estabelecidas entre as duas civilizações são imediatamente destruídas.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_WAR_ADV_QUEST">
-			<Text>A guerra afeta as minhas rotas de comércio?</Text>
+			<Text>A guerra afeta as minhas Rotas de Comércio?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_RELIGION_HEADING2_TITLE">
 			<Text>Rotas Comerciais e Religião</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_RELIGION_HEADING2_BODY">
-			<Text>Rotas comerciais podem estender o alcance da propagação natural da religião. Por exemplo, uma cidade que tem uma religião majoritária pode exercer pressão até 10 hexágonos de distância. Com uma rota comercial, essa pressão pode ser estendida a uma cidade de destino que esteja além do intervalo normal de 10 hexágonos. Tenha em mente que isso acontece para rotas de comércio de entrada e saída.</Text>
+			<Text>Rotas Comerciais podem estender o alcance da propagação natural da religião. Por exemplo, uma cidade que tem uma religião majoritária pode exercer pressão até 10 hexágonos de distância. Com uma Rota Comercial, essa pressão pode ser estendida a uma cidade de destino que esteja além do intervalo normal de 10 hexágonos. Tenha em mente que isso acontece para rotas de comércio de entrada e saída.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_RELIGION_ADV_QUEST">
-			<Text>As rotas de comércio podem espalhar a religião?</Text>
+			<Text>As Rotas de Comércio podem espalhar a Religião?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TRADE_SCIENCE_HEADING2_TITLE">
 			<Text>Rotas Comerciais e Ciência</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_InGameScreens_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_InGameScreens_Expansion2.xml
@@ -2,7 +2,7 @@
 <GameData>
     <Language_pt_BR>
         <Row Tag="TXT_KEY_VP_DIPLO_SOMEONE_WON">
-            <Text>{1_CivName} {1: plural 2?{1: gender feminine?foram eleitas; other?foram eleitos;}; other?{1: gender feminine?foi eleita; other?foi eleito;};} {1: plural 2?Líderes Mundiais; other?Líder Mundial;}.</Text>
+            <Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} {1: plural 2?foram; other?foi;} {1: plural 2?{1: gender feminine?eleitas; other?eleitos;}; other?{1: gender feminine?eleita; other?eleito;};} {1: plural 2?Líderes Mundiais; other?Líder Mundial;}.</Text>
         </Row>
         <Row Tag="TXT_KEY_VP_DIPLO_NEW_CAPITALS_REMAINING">
             <Text>Todos os jogadores continuam no controle de suas [ICON_CAPITAL]Capitais originais.</Text>
@@ -221,10 +221,10 @@
             <Text>GANHO CIENTÍFICO DELES</Text>
         </Row>
         <Row Tag="TXT_KEY_CHOOSE_INTERNATIONAL_TRADE_ROUTE_ITEM_TT_YOUR_SCIENCE_EXPLAINED">
-            <Text>{1_CivName} {1: plural 2?descobriram; other?descobriu;} {2_Num} {2: plural 1?tecnologia; other?tecnologias;} que você não conhece. Você está recebendo {3_Num} de [ICON_RESEARCH]Ciência nesta rota, em razão de sua Influência Cultural sobre eles.</Text>
+            <Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} {1: plural 2?descobriram; other?descobriu;} {2_Num} {2: plural 1?tecnologia; other?tecnologias;} que você não conhece. Você está recebendo {3_Num} de [ICON_RESEARCH]Ciência nesta rota, em razão de sua Influência Cultural sobre eles.</Text>
         </Row>
         <Row Tag="TXT_KEY_CHOOSE_INTERNATIONAL_TRADE_ROUTE_ITEM_TT_THEIR_SCIENCE_EXPLAINED">
-            <Text>Você descobriu {1_Num} {1: plural 1?tecnologia; other?tecnologias;} que {2_CivName} não {2: plural 1?conhece; other?conhecem;}. Eles estão recebendo {3_Num} de [ICON_RESEARCH]Ciência nesta rota, em razão de sua Influência Cultural sobre você.</Text>
+            <Text>Você descobriu {1_Num} {1: plural 1?tecnologia; other?tecnologias;} que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{2_CivName} não {2: plural 1?conhece; other?conhecem;}. Eles estão recebendo {3_Num} de [ICON_RESEARCH]Ciência nesta rota, em razão de sua Influência Cultural sobre você.</Text>
         </Row>
         <Row Tag="TXT_KEY_CHOOSE_INTERNATIONAL_TRADE_ROUTE_ITEM_TT_YOUR_SCIENCE_TOTAL">
             <Text>Total: {1_Num} de [ICON_RESEARCH]Ciência</Text>
@@ -1150,7 +1150,7 @@
             <Text>Uma ou outra vez ao longo da história, surgiram homens e mulheres que mudaram profundamente o mundo a sua volta - artistas, cientistas, generais, comerciantes e outros, cujo gênio colocava sua cabeça e seus ombros acima do resto. Neste jogo tais visionários são chamados de "Grandes Pessoas".[NEWLINE][NEWLINE]Há nove tipos diferentes de Grande Pessoa no jogo: Grandes Comerciantes, Grandes Artistas, Grandes Músicos, Grandes Escritores, Grandes Cientistas, Grandes Engenheiros, Grandes Generais, Grandes Almirantes e Grandes Profetas. Cada um tem uma habilidade especial.[NEWLINE][NEWLINE]Sua civilização adquire Grandes Pessoas através da construção de certos edifícios e maravilhas e, depois, desiginando a eles "especialistas", os cidadãos de suas cidades que desistiram de trabalhar no campo ou nas minas. Embora especialistas não trabalhem nos ladrilhos da cidade, eles aceleraram muito a chegada de uma Grande Pessoa. Equilibrar a necessidade de produção e alimentos e o desejo de Grandes Pessoas é um desafio importante de gestão da cidade.</Text>
         </Row>       <!--New Declare War Screen -->
         <Row Tag="TXT_KEY_DECLARE_WAR_TOP">
-            <Text>Tem certeza que deseja declarar guerra contra {1_CivName}?</Text>
+            <Text>Tem certeza que deseja declarar guerra contra {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName}?</Text>
         </Row>
         <Row Tag="TXT_KEY_DECLARE_WAR_NAME_DESC">
             <Text>{1_PlayerName} ({2_EraName})</Text>
@@ -1159,7 +1159,7 @@
             <Text>Cidades-Estado Aliadas</Text>
         </Row>
         <Row Tag="TXT_KEY_DECLARE_WAR_DEALS_HEADER">
-            <Text>Tratar com {1_CivName}</Text>
+            <Text>Tratar com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName}</Text>
         </Row>
         <Row Tag="TXT_KEY_DECLARE_WAR_DEALS_TURNS_LEFT">
             <Text>{1_Num} {1: plural 1?Turno; other? Turnos;} Restando</Text>
@@ -1168,7 +1168,7 @@
             <Text>De Você</Text>
         </Row>
         <Row Tag="TXT_KEY_DECLARE_WAR_DEALS_FROM_OTHER">
-            <Text>{1: gender feminine?{1: plural 2?{Das}; other?{Da};}; other?{1: plural 2:{Dos}; other?{Do};};} {1_CivName}</Text>
+            <Text>{1: gender *:noart?De; feminine?{1: plural 2?Das; other?Da;}; masculine?{1: plural 2?Dos; other?Do;}; other?De;} {1_CivName}</Text>
         </Row>
         <Row Tag="TXT_KEY_DECLARE_WAR_TRADE_ROUTES_HEADER">
             <Text>Rotas Comerciais</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Jon_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Jon_Expansion2.xml
@@ -502,22 +502,22 @@
             <Text>Você pode presentear esta Cidade-Estado com uma unidade de combate de qualquer lugar do mapa. Ela levará {1_TurnsUntilArrival} {1:plural 1?turno; other?turnos;} para chegar e você não poderá enviar outro presente até que isso aconteça. Assim que ela chegar, você ganhará {2_Influence} de [ICON_INFLUENCE]Influência.</Text>
         </Row>
         <Row Tag="TXT_KEY_CITY_STATE_QUEST_FIND_PLAYER">
-            <Text>Nós ainda estamos procurando novas conexões com {1_CivName:textkey}. Talvez você possa nos ajudar.</Text>
+            <Text>Nós ainda estamos procurando novas conexões com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}. Talvez você possa nos ajudar.</Text>
         </Row>
         <Row Tag="TXT_KEY_CITY_STATE_QUEST_TRADE_ROUTE">
             <Text>Nós queremos que você complete uma rota comercial.</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_QUEST_START_TRADE_ROUTE">
-            <Text>Cidadãos de {@1_MinorCivName} acreditam que nós podemos prosperar mutualmente com uma rota comercial.</Text>
+            <Text>Cidadãos {@1: gender *:noart?de; feminine?{@1: plural 2?das; other?da;}; masculine?{@1: plural 2?dos; other?do;}; other?de;} {@1_MinorCivName} acreditam que nós podemos prosperar mutualmente com uma rota comercial.</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_START_TRADE_ROUTE">
-            <Text>{@1_MinorCivName} {@1: plural 1?deseja; other?desejam} rota comercial</Text>
+            <Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_MinorCivName} {@1: plural 1?deseja; other?desejam} rota comercial</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_QUEST_COMPLETE_TRADE_ROUTE">
-            <Text>Cidad~so de {@1_MinorCivName} estão contentes por verem uma rota comercial conectada. Sua [ICON_INFLUENCE]Influência sobre eles aumentou em [COLOR_POSITIVE_TEXT]{2_InfluenceReward}[ENDCOLOR]!</Text>
+            <Text>Cidadãos {@1: gender *:noart?de; feminine?{@1: plural 2?das; other?da;}; masculine?{@1: plural 2?dos; other?do;}; other?de;} {@1_MinorCivName} estão contentes por verem uma rota comercial conectada. Sua [ICON_INFLUENCE]Influência sobre eles aumentou em [COLOR_POSITIVE_TEXT]{2_InfluenceReward}[ENDCOLOR]!</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_COMPLETE_TRADE_ROUTE">
-            <Text>Rota Comercial estabelecda para {@1_MinorCivName}!</Text>
+            <Text>Rota Comercial estabelecida para {@1: gender *:noart?{}; feminine?{@1: plural 2?as ; other?a ;}; masculine?{@1: plural 2?os ; other?o ;}; other?{};}{@1_MinorCivName}!</Text>
         </Row>
         <Row Tag="TXT_KEY_CITY_STATE_QUEST_TRADE_ROUTE_FORMAL">
             <Text>Eles querem que você complete uma rota comercial terrestre ou marítima com a cidade deles.</Text>
@@ -583,10 +583,10 @@
 			<Text>Princípio da Diplomacia Forçada</Text>
 		</Row>		
         <Row Tag="TXT_KEY_NOTIFICATION_MINOR_WAR_UNIT_HELP">
-            <Text>{@1_MinorCivName} {@1: plural 1?está; other?estão;} procurando por ajuda em sua guerra com {@2_CivName}. Ao presenteá-{@1: plural 1?{@1: gender feminine?las; other?los;}; other?{@1: gender feminine?la; other?lo;};} com unidades, você ganhará mais [ICON_INFLUENCE]Influência que o normal enquanto a guerra ocorrer. O presente pode ser dado a distância, usando a tela de diplomacia da Cidade-Estado, ou movendo uma unidade diretamente ao território deles e selecionando a ação apropriada.</Text>
+            <Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_MinorCivName} {@1: plural 1?está; other?estão;} procurando por ajuda em sua guerra com {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}{@2_CivName}. Ao presenteá-{@1: plural 1?{@1: gender feminine?las; other?los;}; other?{@1: gender feminine?la; other?lo;};} com Unidades, você ganhará mais [ICON_INFLUENCE]Influência que o normal enquanto a guerra ocorrer. O presente pode ser dado a distância, usando a tela de diplomacia da Cidade-Estado, ou movendo uma unidade diretamente ao território deles e selecionando a ação apropriada.</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_WAR_UNIT_HELP">
-            <Text>{@1_MinorCivName} {@1: plural 1?pede; other?pedem;} unidades.</Text>
+            <Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_MinorCivName} {@1: plural 1?pede; other?pedem;} unidades.</Text>
         </Row>
         <Row Tag="TXT_KEY_CITY_STATE_QUEST_GIFT_UNIT">
             <Text>Queremos que você ajude em nossa guerra, presenteando-nos com unidades.</Text>
@@ -605,7 +605,7 @@
             <Text>Você adicionou uma crença de Reforma a sua religião {@1_ReligionName}.</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_REFORMATION_BELIEF_ADDED">
-            <Text>{1_CivName} {1: plural 1?adicionou; 2?adicionaram;} uma crença de Reforma a sua religião {@2_ReligionName}.</Text>
+            <Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} {1: plural 1?adicionou; 2?adicionaram;} uma crença de Reforma a sua religião {@2_ReligionName}.</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_REFORMATION_BELIEF_ADDED_UNKNOWN">
             <Text>Uma civilização desconhecida adicionou uma crença de Reforma em sua religião {@1_ReligionName}.</Text>
@@ -635,7 +635,7 @@
             <Text>ESCOLHER IDEOLOGIA</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_IDEOLOGY_CHOSEN">
-            <Text>{1_CivName} {1: plural 1?adotou; 2?adotaram;} a Ideologia {2_TheirPolicyTree}.</Text>
+            <Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} {1: plural 1?adotou; 2?adotaram;} a Ideologia {2_TheirPolicyTree}.</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_IDEOLOGY_CHOSEN_UNMET">
             <Text>Uma civilização desconhecida adotou a Ideologia {1_TheirPolicyTree}.</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Jon_Inherited_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Jon_Inherited_Expansion2.xml
@@ -37,7 +37,7 @@
             <Text>Eles querem que você lhes dê um presente de ouro.</Text>
         </Row>
         <Row Tag="TXT_KEY_CITY_STATE_QUEST_PLEDGE_TO_PROTECT">
-            <Text>Nós estamos cansados de sermos pressionados {1: plural 2?{1: gender feminine?pelas; masculine?pelos; other?por;}; other?{1: gender feminine?pela; masculine?pelo; other?por;};} {1_CivName:textkey}. Se você prometer publicamente nos proteger, talvez eles possam pensar duas vezes na próxima vez. Nós lhe recompensaremos pelo trabalho.</Text>
+            <Text>Nós estamos cansados de sermos pressionados {1: gender *:noart?por; feminine?{1: plural 2?pelas; other?pela;}; masculine?{1: plural 2?pelos; other?pelo;}; other?por;} {1_CivName:textkey}. Se você prometer publicamente nos proteger, talvez eles possam pensar duas vezes na próxima vez. Nós lhe recompensaremos pelo trabalho.</Text>
         </Row>
         <Row Tag="TXT_KEY_CITY_STATE_QUEST_PLEDGE_TO_PROTECT_FORMAL">
             <Text>Eles querem que você prometa proteção a eles.</Text>
@@ -325,7 +325,7 @@
             <Text>Os líderes {2: gender *:noart?de; feminine?{2: plural 2?das; other?da;}; masculine?{2: plural 2?dos; other?do;}; other?de;} {2_MinorCivName:textkey} estão de olho na prosperidade das outras Cidades-Estado e querem que você os ajude a manter seus rivais em dificuldades. Se você exigir qualquer tipo de tributo {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_TargetName:textkey}, eles o recompensarão.</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_BULLY_CITY_STATE">
-            <Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_MinorCivName:textkey} {2: plural 2?querem; other?quer;} {1_TargetName:textkey} {1: gender *:noart?intimidada; feminine?{1: plural 2?intimidadas; other?intimidada;}; masculine?{1: plural 2?intimidados; other?intimidado;}; other?intimidado;}.</Text>
+            <Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_MinorCivName:textkey} {2: plural 2?querem; other?quer;} {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_TargetName:textkey} {1: gender *:noart?intimidada; feminine?{1: plural 2?intimidadas; other?intimidada;}; masculine?{1: plural 2?intimidados; other?intimidado;}; other?intimidado;}.</Text>
         </Row>
         <Row Tag="TXT_KEY_NOTIFICATION_QUEST_COMPLETE_BULLY_CITY_STATE">
             <Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_MinorCivName:textkey} {2: plural 2?gostaram; other?gostou;} de ver {1: gender masculine?seu rival; other?sua rival;}, {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_TargetName:textkey}, {1: plural 2?se contorcerem e abrirem mão; other?se contorcer e abrir mão;} de valiosos recursos. Sua [ICON_INFLUENCE]Influência com eles aumentou em [COLOR_POSITIVE_TEXT]{3_InfluenceReward}[ENDCOLOR]!</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Leagues_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Leagues_Expansion2.xml
@@ -412,7 +412,7 @@
 			<Text>Congresso Mundial Fundado</Text>
 		</Row>
 		<Row Tag="TXT_KEY_LEAGUE_SPLASH_MESSAGE_FOUNDED">
-			<Text>{@1_CivName} {@1: plural 2?descobriram; other?descobriu;} todas as Civilizações no mundo. Para comemorar, os líderes ao redor do mundo irão se reunir na {2_LeagueName} em {3_TurnsUntilSession} {3: plural 1?turno; other?turnos;} para iniciar discussões sobre diplomacia internacional. À medida que as Civilizações vão avançando pelas eras, este Congresso mudará e novos anfitriões podem ser escolhidos.</Text>
+			<Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_CivName} {@1: plural 2?descobriram; other?descobriu;} todas as Civilizações no mundo. Para comemorar, os líderes ao redor do mundo irão se reunir na {2_LeagueName} em {3_TurnsUntilSession} {3: plural 1?turno; other?turnos;} para iniciar discussões sobre diplomacia internacional. À medida que as Civilizações vão avançando pelas eras, este Congresso mudará e novos anfitriões podem ser escolhidos.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_LEAGUE_SPLASH_MESSAGE_GAME_ERA">
 			<Text>O mundo entrou na {@1_EraName}, seja porque metade das Civilizações também entrou ou uma Civilização entrou na era seguinte.</Text>
@@ -468,25 +468,25 @@
 			<Text>As resoluções propostas à {1_LeagueName} foram decididas.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_LEAGUE_VOTING_RESULT_WORLD_LEADER_PASS">
-			<Text>{@1_CivName} {@1: plural 2?tornaram-se Líderes Mundiais; other?tornou-se Líder Mundial;}</Text>
+			<Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_CivName} {@1: plural 2?tornaram-se Líderes Mundiais; other?tornou-se Líder Mundial;}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_LEAGUE_VOTING_RESULT_WORLD_LEADER_FAIL">
 			<Text>Nenhum Líder Mundial Escolhido</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_LEAGUE_VOTING_RESULT_WORLD_LEADER_PASS_DETAILS">
-			<Text>Obtendo o apoio necessário de no mínimo {1_NumDelegates} {1_NumDelegates: plural 1?Delegado; other?Delegados;}, {@2_CivName} {@2: plural 2?{@2: gender feminine?foram escolhidas as Líderes Mundiais; other?foram escolhidos os Líderes Mundiais;}; other?{@2: gender feminine?foi escolhida a Líder Mundial; other?foi escolhido o Líder Mundial;};}.</Text>
+			<Text>Obtendo o apoio necessário de no mínimo {1_NumDelegates} {1_NumDelegates: plural 1?Delegado; other?Delegados;}, {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}{@2_CivName} {@2: plural 2?{@2: gender feminine?foram escolhidas as Líderes Mundiais; other?foram escolhidos os Líderes Mundiais;}; other?{@2: gender feminine?foi escolhida a Líder Mundial; other?foi escolhido o Líder Mundial;};}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_LEAGUE_VOTING_RESULT_WORLD_LEADER_FAIL_DETAILS">
 			<Text>Sem a obtenção do apoio necessário de no mínimo {1_NumDelegates} {1_NumDelegates: plural 1?Delegado; other?Delegados;}, a proposta de Liderança Mundial falhou. {2: plural 1?A; other?As;} {2_NumCivilizations} {2_NumCivilizations: plural 1?Civilização mais bem classificada ganhou; other?Civilizações mais bem classificadas ganharam;} permanentemente Delegados adicionais.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_LEAGUE_VOTING_RESULT_HOST_CHANGED_SUMMARY">
-			<Text>{@1_CivName} {@1: plural 2?tornaram-se; other?tornou-se;} {@1: plural 2?{@1: gender feminine?as anfitriãs; other?os anfitriões;}; other?{@1: gender feminine?a anfitriã; other?o anfitrião;};}</Text>
+			<Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_CivName} {@1: plural 2?tornaram-se; other?tornou-se;} {@1: plural 2?{@1: gender feminine?as anfitriãs; other?os anfitriões;}; other?{@1: gender feminine?a anfitriã; other?o anfitrião;};}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_LEAGUE_VOTING_RESULT_HOST_SAME_SUMMARY">
-			<Text>{@1_CivName} {@1: plural 2?permancem; other?permance;} {@1: plural 2?{@1: gender feminine?as anfitriãs; other?os anfitriões;}; other?{@1: gender feminine?a anfitriã; other?o anfitrião;};}</Text>
+			<Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_CivName} {@1: plural 2?permancem; other?permance;} {@1: plural 2?{@1: gender feminine?as anfitriãs; other?os anfitriões;}; other?{@1: gender feminine?a anfitriã; other?o anfitrião;};}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_LEAGUE_VOTING_RESULT_HOST_DETAILS">
-			<Text>A Sessão Especial da {1_LeagueName} escolheu {@2_CivName} para {@2: plural 2?serem; other?ser;} {@2: plural 2?{@2: gender feminine?as próximas as anfitriãs; other?os próximos anfitriões;}; other?{@2: gender feminine?a próxima anfitriã; other?o próximo anfitrião;};}.</Text>
+			<Text>A Sessão Especial da {1_LeagueName} escolheu {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}{@2_CivName} para {@2: plural 2?serem; other?ser;} {@2: plural 2?{@2: gender feminine?as próximas as anfitriãs; other?os próximos anfitriões;}; other?{@2: gender feminine?a próxima anfitriã; other?o próximo anfitrião;};}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_LEAGUE_VOTING_RESULT_PASS_SUMMARY">
 			<Text>{1_ResolutionName} Aceita</Text>
@@ -507,7 +507,7 @@
 			<Text>{1_ResolutionName} não foi aceita.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_LEAGUE_VOTING_RESULT_MEMBER_VOTE">
-			<Text>[ICON_BULLET]{1_NumVotes} para {2_ResolutionChoiceText} {@3: plural 2?{@3: gender feminine?das; other?dos;}; other?{@3: gender feminine?da; other?do;}; {@3_CivName}</Text>
+			<Text>[ICON_BULLET]{1_NumVotes} para {2_ResolutionChoiceText} {@3: gender *:noart?de; feminine?{@3: plural 2?das; other?da;}; masculine?{@3: plural 2?dos; other?do;}; other?de;} {@3_CivName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_LEAGUE_VOTING_SOON">
 			<Text>Sessão Vindoura</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_WorldView_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_WorldView_Expansion2.xml
@@ -93,7 +93,7 @@
 			<Text>Capacidade de Carga</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UPANEL_CARGO_CAPACITY_TT">
-		  <Text>Número de unidades que podem ser transportadas {1: gender feminine?{1: plural 2?pelas; other?pela;}; other?{1: plural 2?pelos; other?pelo;};} {1_UnitName}.</Text>
+		  <Text>Número de unidades que podem ser transportadas {1: gender *:noart?por; feminine?{1: plural 2?pelas; other?pela;}; masculine?{1: plural 2?pelos; other?pelo;}; other?por;} {1_UnitName}.</Text>
 	</Row>
 	</Language_pt_BR>
 </GameData>

--- a/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos.xml
+++ b/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos.xml
@@ -63,9 +63,9 @@
             <Text>Você</Text>
         </Row>
         <Row Tag="TXT_KEY_UNMET_PLAYER">
-            <Text>Jogador desconhecido</Text>	
-			<Gender>neutro</Gender>
-			<Plurality>1</Plurality>			
+            <Text>Jogador desconhecido|Jogadores desconhecidos</Text>
+            <Gender>neutro|neutro</Gender>
+            <Plurality>1|2</Plurality>
         </Row>
         <Row Tag="TXT_KEY_CURRENTLY_SELECTED_UNIT">
             <Text>Esta é a unidade selecionada atualmente.[NEWLINE][NEWLINE](Clique para centralizar a câmera nela)</Text>
@@ -83,13 +83,13 @@
             <Text>Pontos de Civilização</Text>
         </Row>
         <Row Tag="TXT_KEY_POPUP_MINOR_GOLD_GIFT">
-            <Text>Você pode oferecer {@1_CivName: gender feminine?à; other?ao;} {1_CivName:textkey} um presente em Ouro.</Text>
+            <Text>Você pode oferecer {1: gender *:noart?a; feminine?{1: plural 2?às; other?à;}; masculine?{1: plural 2?aos; other?ao;}; other?a;} {1_CivName:textkey} um presente em Ouro.</Text>
         </Row>
         <Row Tag="TXT_KEY_POPUP_MINOR_GOLD_GIFT_AMOUNT">
             <Text>Com {1_NumGold} de [ICON_GOLD]Ouro você ganhará {2_NumFriendship} de [ICON_INFLUENCE]Influência</Text>
         </Row>
         <Row Tag="TXT_KEY_POPUP_MINOR_GOLD_GIFT_CANT">
-            <Text>Com pelo menos {1_NumGold} de [ICON_GOLD]Ouro, você poderá dar {@2_CivName: gender feminine?à; other?ao;} {2_CivName:textkey} um presente.</Text>
+            <Text>Com pelo menos {1_NumGold} de [ICON_GOLD]Ouro, você poderá dar {2: gender *:noart?a; feminine?{2: plural 2?às; other?à;}; masculine?{2: plural 2?aos; other?ao;}; other?a;} {2_CivName:textkey} um presente.</Text>
         </Row>
         <Row Tag="TXT_KEY_RANSOM_POPUP_ABANDON">
             <Text>Não valem a pena. Deixe-os.</Text>
@@ -248,7 +248,7 @@
             <Text>Uma unidade civil foi capturada por bárbaros!</Text>
         </Row>
         <Row Tag="TXT_KEY_UNIT_CAPTURED_DETAILED">
-            <Text>{TXT_KEY_GRAMMAR_UPPER_A_AN &lt;&lt; {@1_UnitName}} foi {@1_UnitName: gender feminine?capturada; other?capturado;} por {2_CivName:textkey}!</Text>
+            <Text>{TXT_KEY_GRAMMAR_UPPER_A_AN &lt;&lt; {@1_UnitName}} foi {@1_UnitName: gender feminine?capturada; other?capturado;} {2: gender *:noart?por; feminine?{2: plural 2?pelas; other?pela;}; masculine?{2: plural 2?pelos; other?pelo;}; other?por;} masculine?{1: plural 2?pelos; other?pelo;} {2_CivName:textkey}!</Text>
         </Row>
         <Row Tag="TXT_KEY_UNIT_CAPTURED_BARBS_DETAILED">
             <Text>{TXT_KEY_GRAMMAR_UPPER_A_AN &lt;&lt; {@1_UnitName}} foi {@1_UnitName: gender feminine?capturada; other?capturado;} pelos bárbaros! Eles {@1_UnitName: gender feminine?a; other?o;} levarão ao acampamento mais próximo. Caso queira recuperá-{@1_UnitName: gender feminine?la; other?lo;}, terá que segui-los e atacá-los!</Text>
@@ -926,10 +926,10 @@
             <Text>Você deseja designar civis a hexágonos diferentes?</Text>
         </Row>
         <Row Tag="TXT_KEY_POP_GIVE_UNIT_CONFIRMATION">
-            <Text>Você quer presentear {1_CivName} com a unidade {2_UnitName}?</Text>
+            <Text>Você quer presentear {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName} com a unidade {2_UnitName}?</Text>
         </Row>
         <Row Tag="TXT_KEY_POP_RETURN_CIVILIAN_CONFIRMATION">
-            <Text>Você capturou um civil que pertencia {@1: gender *:noart?a; feminine?{@1: plural 2?às; other?à;}; masculine?{@1: plural 2?aos; other?ao;}; other?a;} {1_CivName}. Você tem a opção de libertá-lo ou levá-lo com você como {@2_NewUnitName}.</Text>
+            <Text>Você capturou um civil que pertencia {1: gender *:noart?a; feminine?{1: plural 2?às; other?à;}; masculine?{1: plural 2?aos; other?ao;}; other?a;} {1_CivName}. Você tem a opção de libertá-lo ou levá-lo com você como {@2_NewUnitName}.</Text>
         </Row>
         <Row Tag="TXT_KEY_POP_RETURN_CIVILIAN_CITY_STATE">
             <Text>Liberando o civil, você ganhará {1_Num} de [ICON_INFLUENCE]Influência!</Text>
@@ -1288,7 +1288,7 @@
 			<Text>Você tem certeza que quer denunciar {@1_LeaderName} publicamente?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CONFIRM_WAR_PROTECTED_CITY_STATE">
-		  <Text>Você tem certeza que quer declarar guerra contra {1_CivName:textkey}? Atualmente eles estão sob proteção de: </Text>
+		  <Text>Você tem certeza que quer declarar guerra contra {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}? Atualmente eles estão sob proteção de: </Text>
 		</Row>
 		<!-- Resources UI -->
 		<Row Tag="TXT_KEY_IC_RESOURCE">

--- a/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos.xml
+++ b/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos.xml
@@ -248,7 +248,7 @@
             <Text>Uma unidade civil foi capturada por bárbaros!</Text>
         </Row>
         <Row Tag="TXT_KEY_UNIT_CAPTURED_DETAILED">
-            <Text>{TXT_KEY_GRAMMAR_UPPER_A_AN &lt;&lt; {@1_UnitName}} foi {@1_UnitName: gender feminine?capturada; other?capturado;} {2: gender *:noart?por; feminine?{2: plural 2?pelas; other?pela;}; masculine?{2: plural 2?pelos; other?pelo;}; other?por;} masculine?{1: plural 2?pelos; other?pelo;} {2_CivName:textkey}!</Text>
+            <Text>{TXT_KEY_GRAMMAR_UPPER_A_AN &lt;&lt; {@1_UnitName}} foi {@1_UnitName: gender feminine?capturada; other?capturado;} {2: gender *:noart?por; feminine?{2: plural 2?pelas; other?pela;}; masculine?{2: plural 2?pelos; other?pelo;}; other?por;} {2_CivName:textkey}!</Text>
         </Row>
         <Row Tag="TXT_KEY_UNIT_CAPTURED_BARBS_DETAILED">
             <Text>{TXT_KEY_GRAMMAR_UPPER_A_AN &lt;&lt; {@1_UnitName}} foi {@1_UnitName: gender feminine?capturada; other?capturado;} pelos bárbaros! Eles {@1_UnitName: gender feminine?a; other?o;} levarão ao acampamento mais próximo. Caso queira recuperá-{@1_UnitName: gender feminine?la; other?lo;}, terá que segui-los e atacá-los!</Text>

--- a/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos2.xml
+++ b/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos2.xml
@@ -1163,22 +1163,22 @@
             <Text>Você capturou {@1_CityName}!!!</Text>
         </Row>
         <Row Tag="TXT_KEY_MISC_CITY_CAPTURED_BY">
-            <Text>{@1_CityName} foi capturada por {@2_LongCivName}!!!</Text>
+            <Text>{@1_CityName} foi capturada {@2: gender *:noart?por; feminine?{@2: plural 2?pelas; other?pela;}; masculine?{@2: plural 2?pelos; other?pelo;}; other?por;} {@2_LongCivName}!!!</Text>
         </Row>
         <Row Tag="TXT_KEY_MISC_CITY_HAS_BEEN_FOUNDED">
             <Text>{@1_CityName} foi fundada</Text>
         </Row>
         <Row Tag="TXT_KEY_MISC_CITY_HAS_BEEN_RAZED_BY">
-            <Text>{@2_CivName} ateou fogo em {@1_CityName}!!!</Text>
+            <Text>{@2: gender *:noart?{}; feminine?{@2: plural 2?As ; other?A ;}; masculine?{@2: plural 2?Os ; other?O ;}; other?{};}{@2_CivName} dizimou {@1_CityName}!!!</Text>
         </Row>
         <Row Tag="TXT_KEY_MISC_CITY_IS_FOUNDED">
             <Text>{@1_CityName} está fundada</Text>
         </Row>
         <Row Tag="TXT_KEY_MISC_CITY_RAZED_BY">
-            <Text>{@1_CityName} foi incendiada por {@2_LongCivName}!!!</Text>
+            <Text>{@1_CityName} foi dizimada {@2: gender *:noart?por; feminine?{@2: plural 2?pelas; other?pela;}; masculine?{@2: plural 2?pelos; other?pelo;}; other?por;} {@2_LongCivName}!!!</Text>
         </Row>
         <Row Tag="TXT_KEY_MISC_CITY_WAS_CAPTURED_BY">
-            <Text>{@1_CityName} foi capturada por {@2_LongCivName}!!!</Text>
+            <Text>{@1_CityName} foi capturada {@2: gender *:noart?por; feminine?{@2: plural 2?pelas; other?pela;}; masculine?{@2: plural 2?pelos; other?pelo;}; other?por;} {@2_LongCivName}!!!</Text>
         </Row>
         <Row Tag="TXT_KEY_MISC_CITY_WLTKD_ENDED_KNOWN_RESOURCE">
             <Text>A festa "Nós Amamos o Rei" acabou em {@1_CityName}. Ela agora quer [COLOR_HIGHLIGHT_TEXT]{@2_ResourceName}[ENDCOLOR]!</Text>

--- a/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_Advisors.xml
+++ b/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_Advisors.xml
@@ -1009,94 +1009,94 @@
 			<Text>Devemos pesquisar a tecnologia [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_TechName:textkey}[/COLOR], o que nos permitirá melhorar o recurso [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_ResourceName:textkey}[/COLOR] dentro das nossas fronteiras.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARPROJECTION_DESTRUCTION_WAR">
-			<Text>Suplico que peça a paz imediatamente com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR]; eles ameaçam nossa existência!</Text>
+			<Text>Suplico que peça a paz imediatamente com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR]; eles ameaçam nossa existência!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARPROJECTION_DESTRUCTION_PEACE">
-			<Text>Seria sábio não provocar [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR]. Eles são imensamente mais poderosos que nós. Portanto, recomendo que não mexa com eles.</Text>
+			<Text>Seria sábio não provocar {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR]. Eles são imensamente mais poderosos que nós. Portanto, recomendo que não mexa com eles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARPROJECTION_DEFEAT_WAR">
-			<Text>Nossa guerra com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] não está indo bem. Devemos considerar oferecer a paz para acabar com a hostilidade.</Text>
+			<Text>Nossa guerra com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] não está indo bem. Devemos considerar oferecer a paz para acabar com a hostilidade.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARPROJECTION_DEFEAT_PEACE">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] tem uma força militar muito mais forte que nós e seria insensato declarar guerra neste momento.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] tem uma força militar muito mais forte que nós e seria insensato declarar guerra neste momento.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARPROJECTION_STALEMATE_WAR">
-			<Text>Estamos tão forte quanto [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR]; esta guerra irá testar a nossa coragem.</Text>
+			<Text>Estamos tão forte quanto {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR]; esta guerra irá testar a nossa coragem.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARPROJECTION_GOOD_WAR">
-			<Text>Nossa guerra com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] está indo bem e temos uma força de combate mais forte que eles. Mantenha a pressão para conseguirmos a vitória!</Text>
+			<Text>Nossa guerra com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] está indo bem e temos uma força de combate mais forte que eles. Mantenha a pressão para conseguirmos a vitória!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARPROJECTION_GOOD_PEACE">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] é militarmente mais fraco que nós. Se eles possuem algo que queremos, agora seria o momento oportuno para pedir.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] é militarmente mais fraco que nós. Se eles possuem algo que queremos, agora seria o momento oportuno para pedir.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARPROJECTION_VERY_GOOD_WAR">
-			<Text>Com os nossos números, somos capazes de esmagar absolutamente [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR]! Seja rápido antes que eles possam fugir usando algum truque diplomático.</Text>
+			<Text>Com os nossos números, somos capazes de esmagar absolutamente {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR]! Seja rápido antes que eles possam fugir usando algum truque diplomático.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARPROJECTION_VERY_GOOD_PEACE">
-			<Text>Nosso exército é muito mais poderoso que o de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR]. Não estou sugerindo que devamos forçá-los, mas devemos exercer a nossa força propositadamente para sustentar nosso reino glorioso!</Text>
+			<Text>Nosso exército é muito mais poderoso que o {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR]. Não estou sugerindo que devamos forçá-los, mas devemos exercer a nossa força propositadamente para sustentar nosso reino glorioso!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MILITARY_AGGRESSIVE_POSTURE_MEDIUM">
-			<Text>Hmm, isso é interessante. Vimos [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] movendo unidades perto das nossas fronteiras.</Text>
+			<Text>Hmm, isso é interessante. Vimos {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] movendo unidades perto das nossas fronteiras.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MILITARY_AGGRESSIVE_POSTURE_HIGH">
-			<Text>Temos visto [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] movimentar uma série de unidades em torno das nossas fronteiras. Eles podem estar se preparando para um ataque.</Text>
+			<Text>Temos visto {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] movimentar uma série de unidades em torno das nossas fronteiras. Eles podem estar se preparando para um ataque.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MILITARY_AGGRESSIVE_POSTURE_INCREDIBLE">
-			<Text>Isso não pode ser bom. [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] reuniu um enorme exército em nossas fronteiras! Devemos nos preparar para um ataque furtivo.</Text>
+			<Text>Isso não pode ser bom. {1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] reuniu um enorme exército em nossas fronteiras! Devemos nos preparar para um ataque furtivo.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_EXPANSION_AGGRESSIVE_POSTURE_MEDIUM">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] expandiu-se para mais perto do nosso território.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] expandiu-se para mais perto do nosso território.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_EXPANSION_AGGRESSIVE_POSTURE_HIGH">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] estão consumindo grande parte da terra perto das nossas cidades. Podemos precisar discutir este assunto com eles.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] estão consumindo grande parte da terra perto das nossas cidades. Podemos precisar discutir este assunto com eles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_EXPANSION_AGGRESSIVE_POSTURE_INCREDIBLE">
-			<Text>A apropriação de terras por [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_CivName:textkey}[/COLOR] parece estar tentando sufocar nossas cidades com suas fronteiras! Precisamos tomar medidas sobre isso ou não teremos nenhuma saída senão a guerra!</Text>
+			<Text>A apropriação de terras {1: gender *:noart?por; feminine?{1: plural 2?pelas; other?pela;}; masculine?{1: plural 2?pelos; other?pelo;}; other?por;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_CivName:textkey}[/COLOR] parece estar tentando sufocar nossas cidades com suas fronteiras! Precisamos tomar medidas sobre isso ou não teremos nenhuma saída senão a guerra!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARMONGER_THREAT_NONE">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] parece ser bastante pacífica com outras civilizações. Porém, tenho certeza que eles estão aprontando alguma coisa!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] parece ser bastante pacífica com outras civilizações. Porém, tenho certeza que eles estão aprontando alguma coisa!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARMONGER_THREAT_MINOR">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] tem sido hostil com outras civilizações. Devemos ficar atentos.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] tem sido hostil com outras civilizações. Devemos ficar atentos.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARMONGER_THREAT_MAJOR">
-			<Text>Eu sinto que [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] é hostil e aprecia atacar as civilizações menores e Cidades-Estado próximas. Minha mãe me disse que a melhor coisa para um valentão é um soco no nariz!</Text>
+			<Text>Eu sinto que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] é hostil e aprecia atacar as civilizações menores e Cidades-Estado próximas. Minha mãe me disse que a melhor coisa para um valentão é um soco no nariz!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARMONGER_THREAT_SEVERE">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] está atacando todos! Esconda suas mulheres e crianças e proteja nossa capital, assim eles não conseguirão uma vitória por dominação!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] está atacando todos! Esconda suas mulheres e crianças e proteja nossa capital, assim eles não conseguirão uma vitória por dominação!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_WARMONGER_THREAT_CRITICAL">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] move-se pela sede de sangue! Com seu histórico de hostilidade para com todos a sua volta, é só uma questão de tempo para que eles nos ataquem!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] move-se pela sede de sangue! Com seu histórico de hostilidade para com todos a sua volta, é só uma questão de tempo para que eles nos ataquem!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MILITARY_STRENGTH_COMPARED_TO_US_PATHETIC">
-			<Text>Eu não tenho certeza se [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] sequer possui um exército. Qualquer hostilidade com eles seria ridiculamente unilateral.</Text>
+			<Text>Eu não tenho certeza se {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] sequer possui um exército. Qualquer hostilidade com eles seria ridiculamente unilateral.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MILITARY_STRENGTH_COMPARED_TO_US_WEAK">
-			<Text>Eu acho que vi a única unidade que [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] possuía. Parecia triste e solitária. Seria trágico para eles se entrassem em uma guerra com alguém com o nosso poder.</Text>
+			<Text>Eu acho que vi a única unidade que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] possuía. Parecia triste e solitária. Seria trágico para eles se entrassem em uma guerra com alguém com o nosso poder.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MILITARY_STRENGTH_COMPARED_TO_US_POOR">
-			<Text>O [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] não possui uma força militar como a nossa, mas não devemos tirar sarro deles durante as reuniões diplomáticas; eles podem se sentir inseguros.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] não possui uma força militar como a nossa, mas não devemos debochar deles durante as reuniões diplomáticas; eles podem se sentir inseguros.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MILITARY_STRENGTH_COMPARED_TO_US_AVERAGE">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] possui militares com a mesma força que o nós.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] possui militares com a mesma força que o nós.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MILITARY_STRENGTH_COMPARED_TO_US_STRONG">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] é militarmente mais forte que nós. Não devemos entrar em combate sem um planejamento cuidadoso e gastar um tempo crescendo e melhorando as nossas unidades de combate.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] é militarmente mais forte que nós. Não devemos entrar em combate sem um planejamento cuidadoso e gastar um tempo crescendo e melhorando as nossas unidades de combate.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MILITARY_STRENGTH_COMPARED_TO_US_POWERFUL">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] não está para brincadeiras. Sua força militar é maior que a nossa. Devemos considerar atacar apenas se as circunstâncias forem terríveis.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] não está para brincadeiras. Sua força militar é maior que a nossa. Devemos considerar atacar apenas se as circunstâncias forem terríveis.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MILITARY_STRENGTH_COMPARED_TO_US_IMMENSE">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] possui um exército que poderia nos expulsar para fora do planeta. Faça tudo o que puder para permanecer em paz com eles e construa militares o mais rápido possível para tornar a nossa situação menos perigosa.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] possui um exército que poderia nos expulsar para fora do planeta. Faça tudo o que puder para permanecer em paz com eles e construa militares o mais rápido possível para tornar a nossa situação menos perigosa.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MINOR_CIV_DISPUTE_LEVEL_WEAK">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] começou a competir conosco em uma aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR].</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] começou a competir conosco em uma aliança com {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR].</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MINOR_CIV_DISPUTE_LEVEL_STRONG">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] está competindo fortemente para ter uma aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR].</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] está competindo fortemente para ter uma aliança com {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR].</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_MINOR_CIV_DISPUTE_LEVEL_FIERCE">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] está agressivamente minando a nossa relação com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR]!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_LongCivName:textkey}[/COLOR] está agressivamente minando a nossa relação com {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR]!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_FINANCESTRATEGY_BROKE_AND_GOING_DOWN_UNIT_MAINTENANCE">
 			<Text>Estamos falidos e não estamos ganhando nenhum dinheiro! Precisamos fazer tudo o que pudermos para sairmos da dívida! Nossa maior despesa corrente ({1_Num} de [ICON_GOLD]Ouro por turno) é a manutenção das unidades. Elimine todas as unidades que não são absolutamente necessárias!</Text>
@@ -1189,106 +1189,106 @@
 			<Text>Estamos fazendo dinheiro!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Temos trabalhado muito para desenvolver esse relacionamento, seria triste perder um aliado devido à negligência.</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Temos trabalhado muito para desenvolver esse relacionamento, seria triste perder um aliado devido à negligência.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_WAR_WITH_MAJOR">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles precisam de ajuda na luta contra [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR]; Se declararmos guerra a essa civilização manteremos a nossa aliança.</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles precisam de ajuda na luta contra {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR]; Se declararmos guerra a essa civilização manteremos a nossa aliança.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_QUEST_ROUTE">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem que construamos uma rota da nossa capital para a sua cidade; Se fizermos isso, manteremos a nossa aliança.</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem que construamos uma rota da nossa capital para a sua cidade; Se fizermos isso, manteremos a nossa aliança.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_QUEST_KILL_CAMP">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem que destruamos um acampamento bárbaro nas proximidades; Se fizermos isso, manteremos a nossa aliança.</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem que destruamos um acampamento bárbaro nas proximidades; Se fizermos isso, manteremos a nossa aliança.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_QUEST_CONNECT_RESOURCE">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem que nos conectemos a  [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_ResourceName:textkey}[/COLOR]; Se fizermos isso poderemos obter mais influência para manter a nossa aliança.</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem que nos conectemos a  [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_ResourceName:textkey}[/COLOR]; Se fizermos isso poderemos obter mais influência para manter a nossa aliança.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_QUEST_CONSTRUCT_WONDER">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem que construamos o edifício [COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_BldgName}[/COLOR]; Se fizermos isso, poderemos obter mais influência para manter a nossa aliança.</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem que construamos {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_BldgName}[/COLOR]; Se fizermos isso, poderemos obter mais influência para manter a nossa aliança.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_QUEST_GREAT_PERSON">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem uma unidade [COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_UnitName}[/COLOR]; se dermos essa unidade, poderemos obter mais influência para manter a nossa aliança.</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem uma unidade [COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_UnitName}[/COLOR]; se dermos essa unidade, poderemos obter mais influência para manter a nossa aliança.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_QUEST_KILL_CITY_STATE">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem que destruamos [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR]; isso poderia assustar outras civilizações, mas sustentaria nossa aliança.</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Eles querem que destruamos {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR]; isso poderia assustar outras civilizações, mas sustentaria nossa aliança.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_QUEST_FIND_PLAYER">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Se quisermos manter a aliança, podemos realizar explorações e tentar entrar em contato com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR] para ganhar mais influência.</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Se quisermos manter a aliança, podemos realizar explorações e tentar entrar em contato com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR] para ganhar mais influência.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_QUEST_FIND_NATURAL_WONDER">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Podemos obter uma fácil influência para manter o relacionamento se encontrarmos uma maravilha natural, então comece a procurar!</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Podemos obter uma fácil influência para manter o relacionamento se encontrarmos uma maravilha natural, então comece a procurar!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_QUEST_CLEAR_BARBARIANS">
-			<Text>Nós vamos perder nossa aliança com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Se quisermos manter a aliança, tente matar os bárbaros que estão perto do território deles.</Text>
+			<Text>Nós vamos perder nossa aliança com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não conseguirmos alguma influência logo. Se quisermos manter a aliança, tente matar os bárbaros que estão perto do território deles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Se você acha que vale a pena manter este relacionamento, devemos agir para aumentar a nossa influência sobre eles.</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Se você acha que vale a pena manter este relacionamento, devemos agir para aumentar a nossa influência sobre eles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_WAR_WITH_MAJOR">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles precisam de ajuda na luta contra [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR]; se declarar guerra a essa civilização, permaneceremos amigos.</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles precisam de ajuda na luta contra {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR]; se declarar guerra a essa civilização, permaneceremos amigos.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_QUEST_ROUTE">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem que construamos uma rota da nossa capital para a sua cidade; Se fizermos isso, manteremos a nossa amizade.</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem que construamos uma rota da nossa capital para a sua cidade; Se fizermos isso, manteremos a nossa amizade.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_QUEST_KILL_CAMP">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem que destruamos um acampamento bárbaro nas proximidades; Se fizermos isso, manteremos a nossa amizade.</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem que destruamos um acampamento bárbaro nas proximidades; Se fizermos isso, manteremos a nossa amizade.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_QUEST_CONNECT_RESOURCE">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem que nos conectemos ao recurso [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_ResourceName:textkey}[/COLOR]; Se fizermos isso, poderemos obter mais influência para manter a nossa amizade.</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem que nos conectemos ao recurso [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_ResourceName:textkey}[/COLOR]; Se fizermos isso, poderemos obter mais influência para manter a nossa amizade.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_QUEST_CONSTRUCT_WONDER">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem que construamos o edifício [COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_BldgName}[/COLOR]; Se fizermos isso, poderemos obter mais influência para manter a nossa amizade.</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem que construamos {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_BldgName}[/COLOR]; Se fizermos isso, poderemos obter mais influência para manter a nossa amizade.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_QUEST_GREAT_PERSON">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem uma unidade [COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_UnitName}[/COLOR]; se dermos essa unidade, poderemos obter mais influência para manter a nossa amizade.</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem uma unidade [COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_UnitName}[/COLOR]; se dermos essa unidade, poderemos obter mais influência para manter a nossa amizade.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_QUEST_KILL_CITY_STATE">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem que destruamos [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR]; isso poderia assustar outras civilizações, mas sustentaria nossa amizade</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Eles querem que destruamos {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR]; isso poderia assustar outras civilizações, mas sustentaria nossa amizade</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_QUEST_FIND_PLAYER">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Se quisermos manter a amizade, podemos realizar explorações e tentar entrar em contato com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR] para ganhar mais influência.</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Se quisermos manter a amizade, podemos realizar explorações e tentar entrar em contato com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR] para ganhar mais influência.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_QUEST_FIND_NATURAL_WONDER">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Podemos obter uma fácil influência para manter o relacionamento se encontrarmos uma maravilha natural, então comece a procurar!</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não fizermos algo logo. Podemos obter uma fácil influência para manter o relacionamento se encontrarmos uma maravilha natural, então comece a procurar!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_QUEST_CLEAR_BARBARIANS">
-			<Text>Nós vamos deixar de ser amigos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não ganharmos mais influência logo. Se quisermos manter a amizade, tente matar os bárbaros que estão perto do território deles.</Text>
+			<Text>Nós vamos deixar de ser amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se não ganharmos mais influência logo. Se quisermos manter a amizade, tente matar os bárbaros que estão perto do território deles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE">
-			<Text>Podemos ganhar influência sobre [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se dermos algum dinheiro ou uma unidade.</Text>
+			<Text>Podemos ganhar influência sobre {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se dermos algum dinheiro ou uma unidade.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_WAR_WITH_MAJOR">
-			<Text>Se quiser melhorar nossas relações com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR], eles precisam de ajuda na luta contra [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR].</Text>
+			<Text>Se quiser melhorar nossas relações com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR], eles precisam de ajuda na luta contra {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR].</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_QUEST_ROUTE">
-			<Text>Usando nossos [COLOR_UNIT_TEXT]Trabalhadores[/COLOR] para construir uma rota da nossa capital para [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] iria melhorar nosso relacionamento.</Text>
+			<Text>Usando nossos [COLOR_UNIT_TEXT]Trabalhadores[/COLOR] para construir uma rota da nossa capital para {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] iria melhorar nosso relacionamento.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_QUEST_KILL_CAMP">
-			<Text>Podemos ganhar influência sobre [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se destruirmos um campo bárbaro perto deles.</Text>
+			<Text>Podemos ganhar influência sobre {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se destruirmos um campo bárbaro perto deles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_QUEST_CONNECT_RESOURCE">
-			<Text>Podemos ganhar influência sobre [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se nos conectarmos ao recurso [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_ResourceName:textkey}[/COLOR].</Text>
+			<Text>Podemos ganhar influência sobre {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se nos conectarmos ao recurso [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_ResourceName:textkey}[/COLOR].</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_QUEST_CONSTRUCT_WONDER">
-			<Text>Podemos ganhar influência sobre [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se construirmos o edifício [COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_BldgName}[/COLOR].</Text>
+			<Text>Podemos ganhar influência sobre {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] se construirmos {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_BldgName}[/COLOR].</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_QUEST_GREAT_PERSON">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] estaria totalmente impressionada se tivéssemos uma unidade [COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_UnitName}[/COLOR]. Providencie uma dessas!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] estaria totalmente impressionada se tivéssemos uma unidade [COLOR_ADVISOR_HIGHLIGHT_TEXT]{@2_UnitName}[/COLOR]. Providencie uma dessas!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_QUEST_KILL_CITY_STATE">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] quer que destruamos [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR]! Por que eles querem isso? Soa cruel, mas eu tenho certeza que é por uma razão perfeitamente válida.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] quer que destruamos {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_MinorCivName:textkey}[/COLOR]! Por que eles querem isso? Soa cruel, mas eu tenho certeza que é por uma razão perfeitamente válida.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_QUEST_FIND_PLAYER">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] quer que entremos em contato com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_CivName:textkey}[/COLOR]. Se a encontramos em nossas explorações, ganharíamos uma influência facilmente.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] quer que entremos em contato com {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_CivName:textkey}[/COLOR]. Se a encontramos em nossas explorações, ganharíamos uma influência facilmente.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_QUEST_FIND_NATURAL_WONDER">
-			<Text>A descoberta de uma maravilha natural nos daria mais influência sobre [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR].</Text>
+			<Text>A descoberta de uma maravilha natural nos daria mais influência sobre {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR].</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_QUEST_CLEAR_BARBARIANS">
-			<Text>Matar todos os bárbaros perto do território de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] nos dará alguma influência sobre eles.</Text>
+			<Text>Matar todos os bárbaros perto do território {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] nos dará alguma influência sobre eles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLOSTRATEGY_LIBERATE_CITY_STATE">
-			<Text>[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] foi capturada por [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR]. Se capturarmos a cidade e libertá-la, restauraríamos a Cidade-Estado de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{3_MinorCivName:textkey}[/COLOR] e ganharíamos uma enorme quantidade de influência sobre eles.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_MinorCivName:textkey}[/COLOR] foi capturada {2: gender *:noart?por; feminine?{2: plural 2?pelas; other?pela;}; masculine?{2: plural 2?pelos; other?pelo;}; other?por;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR]. Se capturarmos a cidade e libertá-la, restauraríamos a Cidade-Estado {3: gender *:noart?de; feminine?{3: plural 2?das; other?da;}; masculine?{3: plural 2?dos; other?do;}; other?de;} [COLOR_ADVISOR_HIGHLIGHT_TEXT]{3_MinorCivName:textkey}[/COLOR] e ganharíamos uma enorme quantidade de influência sobre eles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_SCIENCESTRATEGY_INFO">
 			<Text>Nossa civilização está produzindo {1_Num} {1_Num: plural 1?ponto; other?pontos;} de [ICON_RESEARCH]ciência com {2_Num} de [ICON_CITIZEN]população.</Text>
@@ -1327,10 +1327,10 @@
 			<Text>Existe uma fonte de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_ResourceName:textkey}[/COLOR] perto da cidade [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_CityName:textkey}[/COLOR]. Nós já temos esse recurso, mas poderíamos usar qualquer adicional em negociações diplomáticas.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_RESOURCESTRATEGY_TRADE_LUXURIES">
-			<Text>Temos recursos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_ResourceName:textkey}[/COLOR] adicionais que podemos usar para negociar com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR], que não os possui. Devemos tentar fechar um acordo com eles.</Text>
+			<Text>Temos recursos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_ResourceName:textkey}[/COLOR] adicionais que podemos usar para negociar com {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR], que não os possui. Devemos tentar fechar um acordo com eles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_RESOURCESTRATEGY_TRADE_STRATEGIC">
-			<Text>Temos recursos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_ResourceName:textkey}[/COLOR] adicionais que podemos usar para negociar com [COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR] que não os possui. Pense bem ao negociar esse recurso com eles, pois eles podem usá-lo para treinar unidades que podem, eventualmente, serem usadas contra nós.</Text>
+			<Text>Temos recursos de [COLOR_ADVISOR_HIGHLIGHT_TEXT]{1_ResourceName:textkey}[/COLOR] adicionais que podemos usar para negociar com {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}[COLOR_ADVISOR_HIGHLIGHT_TEXT]{2_LongCivName:textkey}[/COLOR] que não os possui. Pense bem ao negociar esse recurso com eles, pois eles podem usá-lo para treinar unidades que podem, eventualmente, serem usadas contra nós.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BASESTRATEGY_NOTHING_TO_SAY_ECONOMIC">
 			<Text>Por favor, me perdoe; Lamento por não ter conselhos muito úteis neste momento. Talvez você deva construir mais cidades?</Text>

--- a/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_Jon.xml
+++ b/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_Jon.xml
@@ -19,10 +19,10 @@
 		</Row>
 		<!-- City-State Text -->
 		<Row Tag="TXT_KEY_CITY_STATE_HAS_MESSAGE">
-			<Text>Mensagem da Cidade-Estado de {1_CivName:textkey}.</Text>
+			<Text>Mensagem da Cidade-Estado {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_MET">
-			<Text>Você encontrou a Cidade-Estado de {1_CivName:textkey}.</Text>
+			<Text>Você encontrou a Cidade-Estado {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_RELATIONSHIP_NEUTRAL">
 			<Text>Eles são neutros.</Text>
@@ -58,19 +58,19 @@
 			<Text>Ou você está em guerra com o aliado desta Cidade-Estado ou você atacou tantas Cidades-Estado, que nenhuma delas irá negociar com você novamente!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_GREETING_FRIENDLY">
-			<Text>Saudações grande líder. Nós representamos {1_CivName:textkey}. Sinceramente esperamos paz forte e duradoura com seu poderoso Império. {2_DetailsString} Confiamos que você nos dará assistência quando precisarmos no futuro. [NEWLINE][NEWLINE]{3_GiftString}[NEWLINE][NEWLINE]{4_SpeakAgainString}</Text>
+			<Text>Saudações grande líder. Nós representamos {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}. Sinceramente esperamos paz forte e duradoura com seu poderoso Império. {2_DetailsString} Confiamos que você nos dará assistência quando precisarmos no futuro. [NEWLINE][NEWLINE]{3_GiftString}[NEWLINE][NEWLINE]{4_SpeakAgainString}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_GREETING_NEUTRAL">
-			<Text>Saudações. Nós somos o povo de {1_CivName:textkey}. Respeite-nos e teremos paz. {2_DetailsString} Buscamos relações de apoio mútuo com os nossos vizinhos: se buscarmos assistência, esperamos que você a forneça e, claro, faremos o mesmo por você. [NEWLINE][NEWLINE]{3_GiftString}[NEWLINE][NEWLINE]{4_SpeakAgainString}</Text>
+			<Text>Saudações. Nós somos o povo {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}. Respeite-nos e teremos paz. {2_DetailsString} Buscamos relações de apoio mútuo com os nossos vizinhos: se buscarmos assistência, esperamos que você a forneça e, claro, faremos o mesmo por você. [NEWLINE][NEWLINE]{3_GiftString}[NEWLINE][NEWLINE]{4_SpeakAgainString}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_GREETING_HOSTILE">
-			<Text>Pare, Forasteiro! Nós somos o poderoso povo de {1_CivName:textkey}. Brinque conosco por sua conta e risco! {2_DetailsString} Se você for privilegiado. Claro que somos autossuficientes, mas se precisarmos de ajuda, esperamos que você atenda prontamente.[NEWLINE][NEWLINE]{3_GiftString}[NEWLINE][NEWLINE]{4_SpeakAgainString}</Text>
+			<Text>Pare, Forasteiro! Nós somos o poderoso povo {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}. Brinque conosco por sua conta e risco! {2_DetailsString} Se você for privilegiado. Claro que somos autossuficientes, mas se precisarmos de ajuda, esperamos que você atenda prontamente.[NEWLINE][NEWLINE]{3_GiftString}[NEWLINE][NEWLINE]{4_SpeakAgainString}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_GREETING_IRRATIONAL">
-			<Text>Ahhhh... Um presságio contou a {1_CivName:textkey} que você um dia iria chegar. {2_DetailsString} Faremos grandes coisas juntos - o seu Império e o nosso. Está escrito nas estrelas![NEWLINE][NEWLINE]{3_GiftString}[NEWLINE][NEWLINE]{4_SpeakAgainString}</Text>
+			<Text>Ahhhh... Um presságio contou {1: gender *:noart?a; feminine?{1: plural 2?às; other?à;}; masculine?{1: plural 2?aos; other?ao;}; other?a;} {1_CivName:textkey} que você um dia iria chegar. {2_DetailsString} Faremos grandes coisas juntos - o seu Império e o nosso. Está escrito nas estrelas![NEWLINE][NEWLINE]{3_GiftString}[NEWLINE][NEWLINE]{4_SpeakAgainString}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MINOR_SPEAK_AGAIN">
-			<Text>(Se você quiser falar com {1_CivName:textkey} novamente, clique na cidade.)</Text>
+			<Text>(Se você quiser falar com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} novamente, clique na cidade.)</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_GREETING_CULTURED">
 			<Text>Somos um povo [COLOR_POSITIVE_TEXT]Culto[ENDCOLOR] e podemos ajudar a melhorar a sua [ICON_CULTURE] [COLOR_POSITIVE_TEXT]Cultura[ENDCOLOR].</Text>
@@ -148,10 +148,10 @@
 			<Text>Eles querem que você destrua a Cidade-Estado de {1_CityStateName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_QUEST_FIND_PLAYER">
-			<Text>Ainda estamos em busca de novas rotas comerciais para {1_CivName:textkey}. Talvez você possa nos ajudar.</Text>
+			<Text>Ainda estamos em busca de novas rotas comerciais para {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}. Talvez você possa nos ajudar.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_QUEST_FIND_PLAYER_FORMAL">
-			<Text>Eles querem que você encontre as terras de {1_CivName:textkey}.</Text>
+			<Text>Eles querem que você encontre as terras {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_QUEST_FIND_NATURAL_WONDER">
 			<Text>Nós ainda desejamos descobrir mais sobre as Maravilhas Naturais deste mundo.</Text>
@@ -350,13 +350,13 @@
 			<Text>{1_PlayerName} entrou na {2_EraString:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_RA_FREE_TECH">
-			<Text>Seu Acordo de Pesquisa com {1_CivName:textkey} está concluído e ele lhe deu um avanço tecnológico!</Text>
+			<Text>Seu Acordo de Pesquisa com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} está concluído e ele lhe deu um avanço tecnológico!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_RA_FREE_TECH_S">
 			<Text>Acordo de Pesquisa completo!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_RA_FREE_TECH_WAR_CANCEL">
-			<Text>Seu Acordo de Pesquisa com {1_CivName:textkey} foi cancelado porque vocês estão em guerra agora.</Text>
+			<Text>Seu Acordo de Pesquisa com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} foi cancelado porque vocês estão em guerra agora.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_RA_FREE_TECH_WAR_CANCEL_S">
 			<Text>Acordo de Pesquisa cancelado!</Text>
@@ -392,7 +392,7 @@
 			<Text>{1_CityName:textkey} pode disparar contra um inimigo!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_BEST_IN_GREAT_PEOPLE_ANOTHER">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {1_CivName:textkey} {1: plural 1?{1: gender feminine?é reconhecida; masculine?é reconhecido; other? ;}; other?{1: gender feminine?são reconhecidas; masculine?são reconhecidos; other? ;};} como a civilização que mais possui Grandes Pessoas, ganhando {2_Num} {2: plural 1?ponto; other?pontos;} de Civilização por isso. Outro jogador precisará de pelo menos {3_Num} {3: plural 1?Grande Pessoa; other?Grandes Pessoas} para ganhar este título.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?{1: gender feminine?é reconhecida; masculine?é reconhecido; other? ;}; other?{1: gender feminine?são reconhecidas; masculine?são reconhecidos; other? ;};} como a civilização que mais possui Grandes Pessoas, ganhando {2_Num} {2: plural 1?ponto; other?pontos;} de Civilização por isso. Outro jogador precisará de pelo menos {3_Num} {3: plural 1?Grande Pessoa; other?Grandes Pessoas} para ganhar este título.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_BEST_IN_GREAT_PEOPLE_UNMET">
 			<Text>Uma desconhecida Civilização é a que mais possui Grandes Pessoas no mundo! Este título lhe dá {1_Num} {1: plural 1?ponto; other?pontos;} de Civilização. Outro jogador precisará de pelo menos {2_Num} {2: plural 1?Grande Pessoa; other?Grandes Pessoas} para ganhar este título.</Text>
@@ -401,7 +401,7 @@
 			<Text>Sua Civilização é a que mais possui Grandes Pessoas em todo mundo, dando {1_Num} {1: plural 1?ponto; other?pontos} de Civilização a você por isso! Outro jogador precisará de pelo menos {2_Num} {2: plural 1?Grande Pessoa; other?Grandes Pessoas} para ganhar este título de você.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_BEST_IN_POLICIES_ANOTHER">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {1_CivName:textkey} {1: plural 1?{1: gender feminine?é honrada por ser; masculine?é honrado por ser; other? ;}; other?{1: gender feminine?são honradas por serem; masculine?são honrados por serem; other? ;};} a Civilização que mais possui Políticas Sociais, ganhando {2_Num} {2: plural 1?ponto; other?pontos} de Civilização por isso. Outro jogador precisará ter pelo menos {3_Num} {3: plural 1?Política Social; other?Políticas Sociais} para ganhar este título.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?{1: gender feminine?é honrada por ser; masculine?é honrado por ser; other? ;}; other?{1: gender feminine?são honradas por serem; masculine?são honrados por serem; other? ;};} a Civilização que mais possui Políticas Sociais, ganhando {2_Num} {2: plural 1?ponto; other?pontos} de Civilização por isso. Outro jogador precisará ter pelo menos {3_Num} {3: plural 1?Política Social; other?Políticas Sociais} para ganhar este título.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_BEST_IN_POLICIES_UNMET">
 			<Text>Um jogador desconhecido é honrado por ser a Civilização que mais possui Políticas Sociais, ganhando {1_Num} {1: plural 1?ponto; other?pontos} de Civilização por isso. Outro jogador precisará ter pelo menos {2_Num} {2: plural 1?Política Social; other?Políticas Sociais} para reivindicar este título.</Text>
@@ -410,7 +410,7 @@
 			<Text>Sua Civilização é a que possui mais Políticas Sociais no mundo, ganhando {1_Num} {1: plural 1?ponto; other?pontos} de Civilização por isso! Outro jogador precisará ter pelo menos {2_Num} {2: plural 1?Política Social; other?Políticas Sociais} para tomar este título de você.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_BEST_IN_WONDERS_ANOTHER">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {1_CivName:textkey} {1: plural 1?{1: gender feminine?é reconhecida; masculine?é reconhecido; other? ;}; other?{1: gender feminine?são reconhecidas; masculine?são reconhecidos; other? ;};} como a Civilização que mais possui Maravilhas, ganhando {2_Num} {2: plural 1?ponto; other?pontos} de Civilização por isso. Outro jogador precisará ter pelo menos {3_Num} {3: plural 1?Maravilha; other?Maravilhas} para reivindicar este título.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?{1: gender feminine?é reconhecida; masculine?é reconhecido; other? ;}; other?{1: gender feminine?são reconhecidas; masculine?são reconhecidos; other? ;};} como a Civilização que mais possui Maravilhas, ganhando {2_Num} {2: plural 1?ponto; other?pontos} de Civilização por isso. Outro jogador precisará ter pelo menos {3_Num} {3: plural 1?Maravilha; other?Maravilhas} para reivindicar este título.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_BEST_IN_WONDERS_UNMET">
 			<Text>Uma desconhecida Civilização possui atualmente o maior número de Maravilhas construídas, ganhando assim {1_Num} {1: plural 1?ponto; other?pontos} de Civilização! Outro jogador precisará construir pelo menos {2_Num} {2: plural 1?Maravilha; other?Maravilhas} para ter este título.</Text>
@@ -425,43 +425,43 @@
 			<Text>A cidade {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CityName:textkey} possui atualmente {2_Population} [ICON_CITIZEN]{2: plural 1?cidadão; other?cidadãos;}! O novo cidadão trabalhará automaticamente nas terras próximas à cidade para aquisição de mais [ICON_FOOD]Alimentos, [ICON_PRODUCTION]Produção ou [ICON_GOLD]Ouro.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_DEFENSIVE_PACT_FROM_US">
-			<Text>Nosso pacto defensivo com {1: plural 1?{1: gender *:noart? ; feminine?a; masculine?o; other? ;}; other?{1: gender *:noart? ; feminine?as; masculine?os; other? ;};} {1_CivName:textkey} terminou.</Text>
+			<Text>Nosso pacto defensivo com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_DEFENSIVE_PACT_TO_US">
-			<Text>O acordo de pacto defensivo que {1_CivName:textkey} tinha conosco terminou.</Text>
+			<Text>O acordo de pacto defensivo que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} tinha conosco terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_GPT_FROM_US">
-			<Text>O acordo que tínhamos com {1_CivName:textkey}, onde fornecíamos [ICON_GOLD]Ouro a cada turno, terminou.</Text>
+			<Text>O acordo que tínhamos com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}, onde fornecíamos [ICON_GOLD]Ouro a cada turno, terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_GPT_TO_US">
-			<Text>O acordo que tínhamos com {1_CivName:textkey}, onde ganhávamos [ICON_GOLD]Ouro a cada turno, terminou.</Text>
+			<Text>O acordo que tínhamos com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}, onde ganhávamos [ICON_GOLD]Ouro a cada turno, terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_OPEN_BORDERS_FROM_US">
-			<Text>O acordo que liberava o acesso às nossas fronteiras para {1_CivName:textkey} terminou.</Text>
+			<Text>O acordo que liberava o acesso às nossas fronteiras para {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_OPEN_BORDERS_TO_US">
-			<Text>O acordo com {1_CivName:textkey}, que nos forneceu livre acesso às suas fronteiras, terminou.</Text>
+			<Text>O acordo com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}, que nos forneceu livre acesso às suas fronteiras, terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_RESEARCH_AGREEMENT_FROM_US">
-			<Text>Nosso acordo de pesquisa com {1_CivName:textkey} terminou.</Text>
+			<Text>Nosso acordo de pesquisa com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_RESEARCH_AGREEMENT_TO_US">
-			<Text>O acordo de pesquisa que {1_CivName:textkey} tinha conosco terminou.</Text>
+			<Text>O acordo de pesquisa que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} tinha conosco terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_RESOURCE_FROM_US">
-			<Text>O acordo em que nós disponibilizávamos {2_Resource} para {1_CivName:textkey} terminou.</Text>
+			<Text>O acordo em que nós disponibilizávamos {2_Resource} para {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_RESOURCE_TO_US">
-			<Text>O acordo em que {1_CivName:textkey} fornecia {2_Resource} para nós terminou.</Text>
+			<Text>O acordo em que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} fornecia {2_Resource} para nós terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_TRADE_AGREEMENT_FROM_US">
-			<Text>Nosso acordo comercial com {1_CivName:textkey} terminou.</Text>
+			<Text>Nosso acordo comercial com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_TRADE_AGREEMENT_TO_US">
-			<Text>O acordo comercial que {1_CivName:textkey} tinha conosco terminou.</Text>
+			<Text>O acordo comercial que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} tinha conosco terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DEAL_EXPIRED_PEACE">
-			<Text>O tratado de paz com {1: plural 1?{1: gender *:noart? ; feminine?a; masculine?o; other? ;}; other?{1: gender *:noart? ; feminine?as; masculine?os; other? ;};} {1_CivName:textkey} terminou. Qualquer uma das Civilizações poderá agora declarar guerra à outra.</Text>
+			<Text>O tratado de paz com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou. Qualquer uma das Civilizações poderá agora declarar guerra à outra.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_PEACE">
 			<Text>Tratado de paz expirou</Text>
@@ -507,22 +507,22 @@
 		</Row>
 		<!-- Notifications relating to Minor Civs -->
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_BARB_KILLED">
-			<Text>Você matou um grupo de Bárbaros próximo a {1_CivName:textkey}! Eles estão gratos e sua [ICON_INFLUENCE]Influência sobre eles aumentou em 12!</Text>
+			<Text>Você eliminou um grupo de Bárbaros próximo {1: gender *:noart?a; feminine?{1: plural 2?às; other?à;}; masculine?{1: plural 2?aos; other?ao;}; other?a;} {1_CivName:textkey}! Eles estão gratos e sua [ICON_INFLUENCE]Influência sobre eles aumentou em 12!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SM_MINOR_BARB_KILLED">
-			<Text>Bárbaros foram mortos nas proximidades de {1_CivName:textkey}!</Text>
+			<Text>Bárbaros foram eliminados nas proximidades {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MET_MINOR_CIV">
 			<Text>Você encontrou a Cidade-Estado {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_INTRUSION">
-			<Text>Você está nas terras de {1_CivName:textkey}! Enquanto suas unidades permanecerem neste território, sua [ICON_INFLUENCE]Influência sobre eles irá diminuir!</Text>
+			<Text>Você está nas terras {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}! Enquanto suas unidades permanecerem neste território, sua [ICON_INFLUENCE]Influência sobre eles irá diminuir!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_LIBERATION_YOU">
-			<Text>Você libertou {1_CivName:textkey}! Eles estão em dívida com você pela sobrevivência.</Text>
+			<Text>Você libertou {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}! Eles estão em dívida com você pela sobrevivência.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_LIBERATION">
-			<Text>{1_MinorCivName:textkey} foi libertada por {2_MajorCivName:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_MinorCivName:textkey} foi libertada {2: gender *:noart?por; feminine?{2: plural 2?pelas; other?pela;}; masculine?{2: plural 2?pelos; other?pelo;}; other?por;} {2_MajorCivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_AGGRESSOR">
 			<Text>Sua agressão contra seus vizinhos mais fracos não passou despercebida. Eles começaram a se reunir para uma defesa mútua e vão lutar até a morte. Se continuar atacando outras Cidades-Estado, mais irão se juntar à aliança.</Text>
@@ -556,201 +556,201 @@
 		</Row>
 		<!-- City-State Quest Notifications -->
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_WAR_QUEST">
-			<Text>{1_CivName:textkey} está sob ataque do {2_CivName:textkey}! Se você não ajudá-los, poderão ser eliminados. Eles pedem ajuda de todas as grandes potências. Se for capaz de eliminar ao menos {3_NumUnits} {3: plural 1?unidade inimiga; other?unidades inimigas}, {1_CivName:textkey} ficará grata a você.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} está sob ataque {2: gender *:noart?de; feminine?{2: plural 2?das; other?da;}; masculine?{2: plural 2?dos; other?do;}; other?de;} {2_CivName:textkey}! Se você não ajudá-los, poderão ser eliminados. Eles pedem ajuda de todas as grandes potências. Se for capaz de eliminar ao menos {3_NumUnits} {3: plural 1?unidade inimiga; other?unidades inimigas}, {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} ficará grata a você.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_WAR_QUEST">
-			<Text>{1_CivName:textkey} atacada pelo {2_CivName:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} atacada {2: gender *:noart?por; feminine?{2: plural 2?pelas; other?pela;}; masculine?{2: plural 2?pelos; other?pelo;}; other?por;} {2_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_WAR_QUEST_COMPLETED">
-			<Text>Você atendeu a um pedido do {1_CivName:textkey} para enfraquecer seu inimigo, o {2_CivName:textkey}! Sua [ICON_INFLUENCE]Influência sobre eles aumentou.</Text>
+			<Text>Você atendeu a um pedido {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} para enfraquecer seu inimigo, {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey}! Sua [ICON_INFLUENCE]Influência sobre eles aumentou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_WAR_QUEST_COMPLETED">
-			<Text>A guerra de {1_CivName:textkey} está completa.</Text>
+			<Text>A guerra {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} está completa.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_WAR_UNIT_HELP">
-			<Text>{1_CivName:textkey} está procurando assistência contra {2_CivName:textkey}. Embora eles prefiram uma participação ativa na guerra, você poderá ajudá-los secretamente, dando-lhes unidades militares. (Clique nesta cidade para fazer isso).</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} está procurando assistência contra {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey}. Embora eles prefiram uma participação ativa na guerra, você poderá ajudá-los secretamente, dando-lhes unidades militares. (Clique nesta cidade para fazer isso).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_WAR_UNIT_HELP">
-			<Text>{1_CivName:textkey} requer unidades.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} requer unidades.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_WAR_QUEST_LOST_CHANCE">
-			<Text>{1_CivName:textkey} não precisa mais da sua ajuda contra {2_CivName:textkey}.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} não precisa mais da sua ajuda contra {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_WAR_QUEST_LOST_CHANCE">
-			<Text>{1_CivName:textkey} não estão mais em guerra</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} não estão mais em guerra</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_BARBS_QUEST">
-			<Text>{1_CivName:textkey} pede sua ajuda contra uma invasão bárbara! Cada Bárbaro que você matar, trará mais [ICON_INFLUENCE]Influência sobre a Cidade-Estado.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} pede sua ajuda contra uma invasão bárbara! Cada Bárbaro que você matar, trará mais [ICON_INFLUENCE]Influência sobre a Cidade-Estado.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_BARBS_QUEST">
-			<Text>{1_CivName:textkey} sob ataque!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} sob ataque!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_BARBS_QUEST_LOST_CHANCE">
-			<Text>{1_CivName:textkey} não precisa mais da sua assistência contra os bárbaros.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} não precisa mais da sua assistência contra os bárbaros.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_BARBS_QUEST_LOST_CHANCE">
-			<Text>{1_CivName:textkey} cancelou o pedido</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} cancelou o pedido</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_START_ROUTE">
-			<Text>{1_CivName:textkey} gostaria que você construísse uma estrada entre sua [ICON_CAPITAL]Capital e a deles!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} gostaria que você construísse uma estrada entre sua [ICON_CAPITAL]Capital e a deles!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_START_ROUTE">
-			<Text>{1_CivName:textkey} pede uma estrada</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} pede uma estrada</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_ROUTE_CONNECTION">
-			<Text>Você [ICON_CONNECTED]conectou com sucesso a sua [ICON_CAPITAL]Capital com {1_CivName:textkey}! Sua [ICON_INFLUENCE]Influência sobre ela aumentou.</Text>
+			<Text>Você [ICON_CONNECTED]conectou com sucesso a sua [ICON_CAPITAL]Capital com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}! Sua [ICON_INFLUENCE]Influência sobre ela aumentou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_ROUTE_CONNECTION">
-			<Text>Estrada para o {1_CivName:textkey}</Text>
+			<Text>Estrada para {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};} {1_CivName:textkey}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_KILL_CAMP">
-			<Text>Os cidadãos de {1_CivName:textkey} estão inquietos com a presença de um acampamento bárbaro nas próximidades e gostariam que alguém o destruísse! Eles irão recompensar generosamente quem o fizer.</Text>
+			<Text>Os cidadãos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} estão inquietos com a presença de um acampamento bárbaro nas próximidades e gostariam que alguém o destruísse! Eles irão recompensar generosamente quem o fizer.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_KILL_CAMP">
-			<Text>{1_CivName:textkey} mira um acampamento próximo.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} mira um acampamento próximo.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_COMPLETE_KILL_CAMP">
-			<Text>Você destruiu com sucesso o acampamento bárbaro que {1_CivName:textkey} havia lhe solicitado que destruísse! Sua [ICON_INFLUENCE]Influência sobre ela cresceu.</Text>
+			<Text>Você destruiu com sucesso o acampamento bárbaro que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} havia lhe solicitado que destruísse! Sua [ICON_INFLUENCE]Influência sobre ela cresceu.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_COMPLETE_KILL_CAMP">
-			<Text>Acampamento destruído para {1_CivName:textkey}!</Text>
+			<Text>Acampamento destruído para {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_QUEST_ENDED_KILL_CAMP">
-			<Text>O acampamento bárbaro que {1_MinorName:textkey} queria que você destruísse, foi destruído por alguém!</Text>
+			<Text>O acampamento bárbaro que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_MinorName:textkey} queria que você destruísse, foi destruído por alguém!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_QUEST_ENDED_KILL_CAMP_S">
-			<Text>{1_MinorName:textkey} não precisa mais da sua ajuda</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_MinorName:textkey} não precisa mais da sua ajuda</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_CONNECT_RESOURCE">
-			<Text>Os comerciantes de {@2_CivName} procuram novas riquezas. Eles ouviram rumores sobre {@1: gender *:noart? ; feminine?{@1: plural 2?as; other?a;}; masculine?{@1: plural 2?os; other?o;}; other? ;} {@1_ResourceName} e do seu grande valor. Você será recompensado se puder ligar esse recurso a sua rota comercial.</Text>
+			<Text>Os comerciantes {@2: gender *:noart?de; feminine?{@2: plural 2?das; other?da;}; masculine?{@2: plural 2?dos; other?do;}; other?de;} {@2_CivName} procuram novas riquezas. Eles ouviram rumores sobre {@1: gender *:noart? ; feminine?{@1: plural 2?as; other?a;}; masculine?{@1: plural 2?os; other?o;}; other? ;} {@1_ResourceName} e do seu grande valor. Você será recompensado se puder ligar esse recurso a sua rota comercial.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_CONNECT_RESOURCE">
-			<Text>{@2_CivName} deseja {@1_ResourceName}</Text>
+			<Text>{@2: gender *:noart?{}; feminine?{@2: plural 2?As ; other?A ;}; masculine?{@2: plural 2?Os ; other?O ;}; other?{};}{@2_CivName} deseja {@1_ResourceName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_COMPLETE_CONNECT_RESOURCE">
-			<Text>Como {@2_CivName} pediu, você conectou {@1_ResourceName} com sucesso a sua rota comercial! Os comerciantes deles estão satisfeitos e o nível de [ICON_INFLUENCE]Influência sobre eles aumentou.</Text>
+			<Text>Como {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}{@2_CivName} pediu, você conectou {@1_ResourceName} com sucesso a sua rota comercial! Os comerciantes deles estão satisfeitos e o nível de [ICON_INFLUENCE]Influência sobre eles aumentou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_COMPLETE_CONNECT_RESOURCE">
-			<Text>{@1_ResourceName} {1: plural 1?{1: gender masculine?conectado; feminine?conectada;}; other?{1: gender masculine?conectados; feminine?conectadas;};} com {@2_CivName}!</Text>
+			<Text>{@1_ResourceName} {1: plural 1?{1: gender masculine?conectado; feminine?conectada;}; other?{1: gender masculine?conectados; feminine?conectadas;};} com {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}{@2_CivName}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_CONSTRUCT_WONDER">
-			<Text>A elite cultural de {@2_CivName} anseia por algo deslumbrante. Eles acreditam que se a maravilha {@1_WonderName} for construída, ela os levará a grandes descobrimentos. Caso você a construa, será amplamente recompensado.</Text>
+			<Text>A elite cultural {@2: gender *:noart?de; feminine?{@2: plural 2?das; other?da;}; masculine?{@2: plural 2?dos; other?do;}; other?de;} {@2_CivName} anseia por algo deslumbrante. Eles acreditam que se a maravilha {@1_WonderName} for construída, ela os levará a grandes descobrimentos. Caso você a construa, será amplamente recompensado.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_CONSTRUCT_WONDER">
-			<Text>{@2_CivName} deseja {@1_WonderName}</Text>
+			<Text>{@2: gender *:noart?{}; feminine?{@2: plural 2?As ; other?A ;}; masculine?{@2: plural 2?Os ; other?O ;}; other?{};}{@2_CivName} deseja {@1_WonderName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_COMPLETE_CONSTRUCT_WONDER">
-			<Text>Como {@2_CivName} pediu, você construiu com sucesso a maravilha {@1_WonderName}! Sua [ICON_INFLUENCE]Influência sobre eles aumentou.</Text>
+			<Text>Como {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}{@2_CivName} pediu, você construiu com sucesso a maravilha {@1_WonderName}! Sua [ICON_INFLUENCE]Influência sobre eles aumentou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_COMPLETE_CONSTRUCT_WONDER">
-			<Text>{@1_WonderName} foi {1: gender masculine?construído; feminine?construída;} para {@2_CivName}!</Text>
+			<Text>{@1_WonderName} foi {1: gender masculine?construído; feminine?construída;} para {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}{@2_CivName}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_ENDED_CONSTRUCT_WONDER">
-			<Text>Outro jogador construiu a maravilha {@1_WonderName}, o que significa que você já não pode satisfazer o pedido de {@2_CivName}.</Text>
+			<Text>Outro jogador construiu a maravilha {@1_WonderName}, o que significa que você já não pode satisfazer o pedido {@2: gender *:noart?de; feminine?{@2: plural 2?das; other?da;}; masculine?{@2: plural 2?dos; other?do;}; other?de;} {@2_CivName}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_ENDED_CONSTRUCT_WONDER">
-			<Text>Você não pode mais construir a maravilha {@1_WonderName} para {@2_CivName}!</Text>
+			<Text>Você não pode mais construir a maravilha {@1_WonderName} para {@2: gender *:noart?{}; feminine?{@2: plural 2?as ; other?a ;}; masculine?{@2: plural 2?os ; other?o ;}; other?{};}{@2_CivName}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_KILL_CITY_STATE">
-			<Text>{2_CivName:textkey} teve uma séria disputa com {1_TargetName:textkey}. {2_CivName:textkey} está à procura de uma grande potência disposta a ajudá-la a resolver isso, por meio da eliminação da sua inimiga. Quem estiver disposto a assumir essa oferta será generosamente recompensado.</Text>
+			<Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_CivName:textkey} teve uma séria disputa com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_TargetName:textkey}. {2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_CivName:textkey} está à procura de uma grande potência disposta a ajudá-la a resolver isso, por meio da eliminação da sua inimiga. Quem estiver disposto a assumir essa oferta será generosamente recompensado.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_KILL_CITY_STATE">
-			<Text>{2_CivName:textkey} {2: plural 1?quer; other?querem;} {1_TargetName:textkey} eliminada.</Text>
+			<Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_CivName:textkey} {2: plural 1?quer; other?querem;} {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_TargetName:textkey} eliminada.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_COMPLETE_KILL_CITY_STATE">
-			<Text>Para a alegria de {2_CivName:textkey}, você eliminou {1_TargetName:textkey}! Eles estão extremamente gratos por sua assistência neste assunto.</Text>
+			<Text>Para a alegria {2: gender *:noart?de; feminine?{2: plural 2?das; other?da;}; masculine?{2: plural 2?dos; other?do;}; other?de;} {2_CivName:textkey}, você eliminou {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_TargetName:textkey}! Eles estão extremamente gratos por sua assistência neste assunto.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_COMPLETE_KILL_CITY_STATE">
-			<Text>{1_TargetName:textkey} foi eliminada por {2_CivName:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_TargetName:textkey} foi eliminada {2: gender *:noart?por; feminine?{2: plural 2?pelas; other?pela;}; masculine?{2: plural 2?pelos; other?pelo;}; other?por;} {2_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_ENDED_KILL_CITY_STATE">
-			<Text>Outro jogador eliminou {1_TargetName:textkey}, impedindo você de satisfazer o pedido que {2_CivName:textkey} lhe fez.</Text>
+			<Text>Outro jogador eliminou {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_TargetName:textkey}, impedindo você de satisfazer o pedido que {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey} lhe fez.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_ENDED_KILL_CITY_STATE">
-			<Text>Você não pode mais eliminar {1_TargetName:textkey} para {2_CivName:textkey}</Text>
+			<Text>Você não pode mais eliminar {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_TargetName:textkey} para {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_GREAT_PERSON">
-			<Text>Os estudiosos de {2_CivName:textkey} buscam a sabedoria de {1: gender feminine?uma; other?um;} {1_UnitName}. Se você conseguir atraí-{1: gender feminine?la; other?lo;} para o seu Império, você será recompensado.</Text>
+			<Text>Os estudiosos {2: gender *:noart?de; feminine?{2: plural 2?das; other?da;}; masculine?{2: plural 2?dos; other?do;}; other?de;} {2_CivName:textkey} buscam a sabedoria de {1: gender feminine?uma; other?um;} {1_UnitName}. Se você conseguir atraí-{1: gender feminine?la; other?lo;} para o seu Império, você será recompensado.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_GREAT_PERSON">
-			<Text>{2_CivName:textkey} busca {1: gender masculine?um; feminine?uma;} {1_UnitName}</Text>
+			<Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_CivName:textkey} busca {1: gender masculine?um; feminine?uma;} {1_UnitName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_COMPLETE_GREAT_PERSON">
-			<Text>Como {2_CivName:textkey} solicitou, você criou com sucesso {1: gender masculine?um; feminine?uma;} {1_UnitName}! Os estudiosos deles estão entusiasmados e sua [ICON_INFLUENCE]Influência sobre eles aumentou.</Text>
+			<Text>Como {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey} solicitou, você criou com sucesso {1: gender masculine?um; feminine?uma;} {1_UnitName}! Os estudiosos deles estão entusiasmados e sua [ICON_INFLUENCE]Influência sobre eles aumentou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_COMPLETE_GREAT_PERSON">
-			<Text>{2_CivName:textkey} saúda {1: gender masculine?seu; feminine?sua;} {1_UnitName}!</Text>
+			<Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_CivName:textkey} saúda {1: gender masculine?seu; feminine?sua;} {1_UnitName}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_FIND_PLAYER">
-			<Text>{2_CivName:textkey} está em busca de novas oportunidades comerciais. Eles ficaram sabendo de um império distante chamado "{1_TargetName:textkey}". Se você for capaz de encontrar território pertencente {1: gender masculine?ao; feminine?à;} {1_TargetName:textkey} você será recompensado.</Text>
+			<Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_CivName:textkey} está em busca de novas oportunidades comerciais. Eles ficaram sabendo de um império distante chamado "{1_TargetName:textkey}". Se você for capaz de encontrar território pertencente {1: gender *:noart?a; feminine?{1: plural 2?às; other?à;}; masculine?{1: plural 2?aos; other?ao;}; other?a;} {1_TargetName:textkey} você será recompensado.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_FIND_PLAYER">
-			<Text>{2_CivName:textkey} procura {1_TargetName:textkey}</Text>
+			<Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};}{2_CivName:textkey} procura {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_TargetName:textkey}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_COMPLETE_FIND_PLAYER">
-			<Text>Sua descoberta {1: gender *:noart?de; masculine?{1: plural 1?do; other?dos;}; feminine?{1: plural 1?da; other?das;};} {1_TargetName:textkey} agradou muito aos comerciantes de {2_CivName:textkey}. Sua [ICON_INFLUENCE]Influência sobre eles aumentou.</Text>
+			<Text>Sua descoberta {1: gender *:noart?de; masculine?{1: plural 1?do; other?dos;}; feminine?{1: plural 1?da; other?das;};} {1_TargetName:textkey} agradou muito aos comerciantes {2: gender *:noart?de; feminine?{2: plural 2?das; other?da;}; masculine?{2: plural 2?dos; other?do;}; other?de;} {2_CivName:textkey}. Sua [ICON_INFLUENCE]Influência sobre eles aumentou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_COMPLETE_FIND_PLAYER">
-			<Text>{1_TargetName:textkey} {1: gender masculine?{1: plural 1?foi descoberto; other?foram descobertos;}; feminine?{1: plural 1?foi descoberta; other?foram descobertas;};} {1: gender masculine?{1: plural 1?pelo; other?pelos;}; feminine?{1: plural 1?pela; other?pelas;};} {2_CivName:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_TargetName:textkey} {1: gender masculine?{1: plural 1?foi descoberto; other?foram descobertos;}; feminine?{1: plural 1?foi descoberta; other?foram descobertas;};} {2: gender *:noart?por; feminine?{2: plural 2?pelas; other?pela;}; masculine?{2: plural 2?pelos; other?pelo;}; other?por;} {2_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_FIND_NATURAL_WONDER">
-			<Text>Os cidadãos mais afortunados de {1_CivName:textkey} ouviram rumores da existência de incríveis Maravilhas Naturais no mundo, que permanecem desconhecidas. Eles esperam que alguém possa investigar essa alegação.</Text>
+			<Text>Os cidadãos mais afortunados {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} ouviram rumores da existência de incríveis Maravilhas Naturais no mundo, que permanecem desconhecidas. Eles esperam que alguém possa investigar essa alegação.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_FIND_NATURAL_WONDER">
-			<Text>{1_CivName:textkey} busca uma nova Maravilha Natural</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} busca uma nova Maravilha Natural</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_COMPLETE_FIND_NATURAL_WONDER">
-			<Text>Você descobriu uma nova Maravilha Natural e tem inspirado aos cidadãos de {1_CivName:textkey}! Por causa dos seus esforços, sua [ICON_INFLUENCE]Influência aumentou com eles.</Text>
+			<Text>Você descobriu uma nova Maravilha Natural e tem inspirado aos cidadãos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}! Por causa dos seus esforços, sua [ICON_INFLUENCE]Influência aumentou com eles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_COMPLETE_FIND_NATURAL_WONDER">
 			<Text>Uma Maravilha Natural foi descoberta {1: gender masculine?{1: plural 1?pelo; other?pelos;}; feminine?{1: plural 1?pela; other?pelas;};} {1_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CITY_STATE_UNIT_SPAWN">
-			<Text>A Cidade-Estado de {1_CivName:textkey} lhe deu uma nova unidade!</Text>
+			<Text>A Cidade-Estado {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} lhe deu uma nova unidade!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_CITY_STATE_UNIT_SPAWN">
-			<Text>Nova unidade vinda de {1_CivName:textkey}!</Text>
+			<Text>Nova unidade vinda {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}!</Text>
 		</Row>
 		<!-- Minor Civ Relations Notifications -->
 		<Row Tag="TXT_KEY_NTFN_SMMRY_MINOR_BEST_RELATIONS_ALL">
-			<Text>{1_MinorName:textkey} tem um novo aliado!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_MinorName:textkey} tem um novo aliado!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_MINOR_NEW_BEST_RELATIONS_ALL">
-			<Text>{1_NewCivName:textkey} substituiu {2_OldCivName:textkey} como {2: gender feminine?{2: plural 1?aliada; other?aliadas;}; other?{2: plural 1?aliado; other?aliados;};} por {3_MinorName:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_NewCivName:textkey} substituiu {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_OldCivName:textkey} como {2: gender feminine?{2: plural 1?aliada; other?aliadas;}; other?{2: plural 1?aliado; other?aliados;};} {3: gender *:noart?por; feminine?{3: plural 2?pelas; other?pela;}; masculine?{3: plural 2?pelos; other?pelo;}; other?por;} {3_MinorName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_MINOR_NOW_BEST_RELATIONS_ALL">
-			<Text>{1_NewCivName:textkey} agora {1: plural 1?{1: gender feminine?é aliada; other?é aliado;}; other?{1: gender feminine?são aliadas; other?são aliados;};} de {2_MinorName:textkey}.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_NewCivName:textkey} agora {1: plural 1?{1: gender feminine?é aliada; other?é aliado;}; other?{1: gender feminine?são aliadas; other?são aliados;};} {2: gender *:noart?de; feminine?{2: plural 2?das; other?da;}; masculine?{2: plural 2?dos; other?do;}; other?de;} {2_MinorName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_SMMRY_MINOR_BEST_RELATIONS_LOST_ALL">
-			<Text>{1_MinorName:textkey} e {2_NewCivName:textkey} não são mais {1: gender feminine?{2: gender feminine?aliadas; other?aliados;}; other?aliados;}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_MinorName:textkey} e {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_NewCivName:textkey} não são mais {1: gender feminine?{2: gender feminine?aliadas; other?aliados;}; other?aliados;}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_MINOR_BEST_RELATIONS_LOST_ALL">
-			<Text>{@1_NewCivName:textkey} não {@1: gender feminine?{@1: plural 1?é mais aliada; other?são mais aliadas;}; other?{@1: plural 1?é mais aliado; other?são mais aliados;};} de {@2_MinorName:textkey}!</Text>
+			<Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_NewCivName:textkey} não {@1: gender feminine?{@1: plural 1?é mais aliada; other?são mais aliadas;}; other?{@1: plural 1?é mais aliado; other?são mais aliados;};} {@2: gender *:noart?de; feminine?{@2: plural 2?das; other?da;}; masculine?{@2: plural 2?dos; other?do;}; other?de;} {@2_MinorName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_MINOR_NOW_ALLIES_ALL">
-			<Text>{1_MajorCivName:textkey}: [ICON_INFLUENCE]Influência sobre {2_MinorName:textkey} aumentou e agora são {1: gender feminine?{2: gender feminine?aliadas; other?aliados;}; other?aliados;}!</Text>
+			<Text>{1_MajorCivName:textkey}: [ICON_INFLUENCE]Influência sobre {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_MinorName:textkey} aumentou e agora são {1: gender feminine?{2: gender feminine?aliadas; other?aliados;}; other?aliados;}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_SMMRY_MINOR_NOW_ALLIES_ALL">
-			<Text>{1_MinorName:textkey} e {2_NewCivName:textkey} são {1: gender feminine?{2: gender feminine?aliadas; other?aliados;}; other?aliados;}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_MinorName:textkey} e {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_NewCivName:textkey} são {1: gender feminine?{2: gender feminine?aliadas; other?aliados;}; other?aliados;}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_MINOR_WERE_ALLIES_NOW_FRIENDS_ALL">
-			<Text>{1_MajorCivName:textkey}: [ICON_INFLUENCE]Influência sobre {2_MinorName:textkey} diminuiu. Eles não são mais {1: gender feminine?{2: gender feminine?aliadas; other?aliados;}; other?aliados;} e sim {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}.</Text>
+			<Text>{1_MajorCivName:textkey}: [ICON_INFLUENCE]Influência sobre {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_MinorName:textkey} diminuiu. Eles não são mais {1: gender feminine?{2: gender feminine?aliadas; other?aliados;}; other?aliados;} e sim {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_SMMRY_MINOR_NOW_FRIENDS_ALL">
-			<Text>{1_MinorName:textkey} e {2_NewCivName:textkey} são {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_MinorName:textkey} e {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_NewCivName:textkey} são {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_MINOR_NOW_FRIENDS_ALL">
-			<Text>{1_MajorCivName:textkey}: [ICON_INFLUENCE]Influência sobre {2_MinorName:textkey} aumentou: eles agora são {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}.</Text>
+			<Text>{1_MajorCivName:textkey}: [ICON_INFLUENCE]Influência sobre {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_MinorName:textkey} aumentou: eles agora são {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_MINOR_WERE_FRIENDS_ALL">
-			<Text>{1_MajorCivName:textkey}: [ICON_INFLUENCE]Influência sobre {2_MinorName:textkey} diminuiu e não são mais {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}!</Text>
+			<Text>{1_MajorCivName:textkey}: [ICON_INFLUENCE]Influência sobre {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_MinorName:textkey} diminuiu e não são mais {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_SMMRY_MINOR_WERE_FRIENDS_ALL">
-			<Text>{1_MinorName:textkey} e {2_NewCivName:textkey} não são mais {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_MinorName:textkey} e {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_NewCivName:textkey} não são mais {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}!</Text>
 		</Row>
 		<!-- Notifications relating to Minor Civ bonuses being granted/taken away -->
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_NOW_FRIENDS_BASE">
-			<Text>A [ICON_INFLUENCE]Influência sobre {1_CivName:textkey} aumentou a ponto de agora serem [COLOR_POSITIVE_TEXT]AMIGOS[ENDCOLOR].[NEWLINE][NEWLINE]{2_DetailsString} Eles também deram permissão para que você possa mover suas unidades pelo território deles.</Text>
+			<Text>A [ICON_INFLUENCE]Influência sobre {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} aumentou a ponto de agora serem [COLOR_POSITIVE_TEXT]AMIGOS[ENDCOLOR].[NEWLINE][NEWLINE]{2_DetailsString} Eles também deram permissão para que você possa mover suas unidades pelo território deles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_NOW_FRIENDS_CULTURE">
 			<Text>Por ser uma Cidade-Estado [COLOR_POSITIVE_TEXT]Cultural[ENDCOLOR], ela te dá raras obras de arte! (+{1_NumCulture} de [ICON_CULTURE]Cultura por turno)</Text>
@@ -762,7 +762,7 @@
 			<Text>Por ser uma Cidade-Estado [COLOR_POSITIVE_TEXT]Marítima[ENDCOLOR], ela irá exportar Alimento para o seu Império (+{1_NumCapitalFood}[ICON_FOOD] para sua [ICON_CAPITAL]Capital, +{2_NumCitiesFood}[ICON_FOOD] para todas as outras cidades).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_FRIENDS_LOST_BASE">
-			<Text>A [ICON_INFLUENCE]Influência sobre {1_CivName:textkey} diminuiu a ponto de vocês não serem mais [COLOR_POSITIVE_TEXT]AMIGOS[ENDCOLOR]...[NEWLINE][NEWLINE]{2_DetailsString} Portanto, suas unidades não terão permissão de se moverem nos territórios deles.</Text>
+			<Text>A [ICON_INFLUENCE]Influência sobre {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} diminuiu a ponto de vocês não serem mais [COLOR_POSITIVE_TEXT]AMIGOS[ENDCOLOR]...[NEWLINE][NEWLINE]{2_DetailsString} Portanto, suas unidades não terão permissão de se moverem nos territórios deles.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_LOST_CULTURE">
 			<Text>({1_NumCulture} de [ICON_CULTURE]Cultura por turno {1: plural 1?foi perdido; other?foram perdidos;})</Text>
@@ -774,10 +774,10 @@
 			<Text>({1_NumCapitalFood}[ICON_FOOD]para a [ICON_CAPITAL]Capital, {2_NumCitiesFood}[ICON_FOOD]para todas as outras cidades)</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_NOW_ALLIES_BASE">
-			<Text>A [ICON_INFLUENCE]Influência sobre {2_MinorCivName:textkey} aumentou a ponto de vocês agora serem [COLOR_POSITIVE_TEXT]ALIADOS[ENDCOLOR].[NEWLINE][NEWLINE]{3_DetailsString}[NEWLINE][NEWLINE]{1_ResourceDetailsString}</Text>
+			<Text>A [ICON_INFLUENCE]Influência sobre {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_MinorCivName:textkey} aumentou a ponto de vocês agora serem [COLOR_POSITIVE_TEXT]ALIADOS[ENDCOLOR].[NEWLINE][NEWLINE]{3_DetailsString}[NEWLINE][NEWLINE]{1_ResourceDetailsString}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_NOW_ALLIES_BASE_PASSED">
-			<Text>A [ICON_INFLUENCE]Influência sobre {3_MinorCivName:textkey} aumentou a ponto de você ter [COLOR_POSITIVE_TEXT]Substituído {1_CivName:textkey} como {1: gender masculine?{1: plural 1?seu aliado; other?seus aliados;}; feminine?{1: plural 1?sua aliada; other?suas aliadas;};}[ENDCOLOR].[NEWLINE][NEWLINE]{4_DetailsString}[NEWLINE][NEWLINE]{2_ResourceDetailsString}</Text>
+			<Text>A [ICON_INFLUENCE]Influência sobre {3: gender *:noart?{}; feminine?{3: plural 2?as ; other?a ;}; masculine?{3: plural 2?os ; other?o ;}; other?{};}{3_MinorCivName:textkey} aumentou a ponto de você ter [COLOR_POSITIVE_TEXT]Substituído {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} como {1: gender masculine?{1: plural 1?seu aliado; other?seus aliados;}; feminine?{1: plural 1?sua aliada; other?suas aliadas;};}[ENDCOLOR].[NEWLINE][NEWLINE]{4_DetailsString}[NEWLINE][NEWLINE]{2_ResourceDetailsString}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_NOW_ALLIES_CULTURE">
 			<Text>Por ser uma Cidade-Estado [COLOR_POSITIVE_TEXT]Cultural[ENDCOLOR], ela dá a você os mais finos artefatos culturais! (+{1_NumCulture} de [ICON_CULTURE]Cultura por turno).</Text>
@@ -792,10 +792,10 @@
 			<Text>Eles agora irão compartilhar seu conhecimento com você! (Você recebe um bônus de [ICON_RESEARCH]Ciência equivalente à geração do Império deles).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_ALLIES_LOST">
-			<Text>A [ICON_INFLUENCE]Influência sobre {1_CivName:textkey} diminuiu ao ponto de vocês não serem mais [COLOR_POSITIVE_TEXT]ALIADOS[ENDCOLOR].[NEWLINE][NEWLINE]{2_DetailsString}[NEWLINE][NEWLINE]Com isso, eles deixarão de lhe fornecer recursos estratégicos e de luxo.</Text>
+			<Text>A [ICON_INFLUENCE]Influência sobre {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} diminuiu ao ponto de vocês não serem mais [COLOR_POSITIVE_TEXT]ALIADOS[ENDCOLOR].[NEWLINE][NEWLINE]{2_DetailsString}[NEWLINE][NEWLINE]Com isso, eles deixarão de lhe fornecer recursos estratégicos e de luxo.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_ALLIES_PASSED">
-			<Text>[COLOR_NEGATIVE_TEXT]{1_CivName:textkey}[ENDCOLOR] tem agora muito mais [ICON_INFLUENCE]Influência sobre {2_MinorCivName:textkey} que você, o que {1: gender masculine?{1: plural 1?o torna o; other?os tornam os;}; feminine?{1: plural 1?a torna a; other?as tornam as;};} mais [COLOR_NEGATIVE_TEXT]{1: gender masculine?{1: plural 1?Novo Aliado; other?Novos Aliados;}; feminine?{1: plural 1?Nova Aliada; other?Novas Aliadas;};}[ENDCOLOR] da Cidade-Estado![NEWLINE][NEWLINE]{3_DetailsString}[NEWLINE][NEWLINE]Com isso, deixarão de lhe fornecer recursos estratégicos e de luxo.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}[COLOR_NEGATIVE_TEXT]{1_CivName:textkey}[ENDCOLOR] tem agora muito mais [ICON_INFLUENCE]Influência sobre {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_MinorCivName:textkey} que você, o que {1: gender masculine?{1: plural 1?o torna o; other?os tornam os;}; feminine?{1: plural 1?a torna a; other?as tornam as;};} mais [COLOR_NEGATIVE_TEXT]{1: gender masculine?{1: plural 1?Novo Aliado; other?Novos Aliados;}; feminine?{1: plural 1?Nova Aliada; other?Novas Aliadas;};}[ENDCOLOR] da Cidade-Estado![NEWLINE][NEWLINE]{3_DetailsString}[NEWLINE][NEWLINE]Com isso, deixarão de lhe fornecer recursos estratégicos e de luxo.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_LOST_ALLIES_MILITARISTIC">
 			<Text>Eles contribuirão com menos unidades para seu exército.</Text>
@@ -810,32 +810,32 @@
 			<Text>Contanto que mantenha seu Status atual, darão a você {1: gender *:noart? ; masculine?{1: plural 1?o; other?os;}; feminine?{1: plural 1?a; other?as;};} [COLOR_POSITIVE_TEXT]{1_ResourceNames}[ENDCOLOR] deles e todos os recursos futuros que vierem a se conectar.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_BFF_NEW_RESOURCE">
-			<Text>Por você ser aliado de {1_CivName:textkey}, eles concedem {2: gender masculine?{2: plural 1?o recém-adquirido; other?os recém-adquiridos;}; feminine?{2: plural 1?a recém-adquirida; other?as recém-adquiridas;};} [COLOR_POSITIVE_TEXT]{2_ResourceNames}[ENDCOLOR]!</Text>
+			<Text>Por você ser aliado {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}, eles concedem {2: gender masculine?{2: plural 1?o recém-adquirido; other?os recém-adquiridos;}; feminine?{2: plural 1?a recém-adquirida; other?as recém-adquiridas;};} [COLOR_POSITIVE_TEXT]{2_ResourceNames}[ENDCOLOR]!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_BFF_NEW_RESOURCE">
-			<Text>{2_ResourceNames} de {1_CivName:textkey}!</Text>
+			<Text>{2_ResourceNames} {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_BFF_LOST_RESOURCE">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {1_CivName:textkey} {1: plural 1?perdeu; other?perderam;} o acesso {2: gender *:noart? ; masculine?{2: plural 1?ao; other?aos;}; feminine?{2:plural 1?à; other?as;};} [COLOR_POSITIVE_TEXT]{2_ResourceNames}[ENDCOLOR] que eles estavam te dando. Nenhuma nova entrega poderá ser realizada até que esteja restabelecido o acesso.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?perdeu; other?perderam;} o acesso {2: gender *:noart? ; masculine?{2: plural 1?ao; other?aos;}; feminine?{2:plural 1?à; other?as;};} [COLOR_POSITIVE_TEXT]{2_ResourceNames}[ENDCOLOR] que eles estavam te dando. Nenhuma nova entrega poderá ser realizada até que esteja restabelecido o acesso.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_BFF_LOST_RESOURCE">
-			<Text>Perdeu-se {2_ResourceNames} de {1_CivName:textkey}!</Text>
+			<Text>Perdeu-se {2_ResourceNames} {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_MINOR_LOST_BEST_RELATIONS_BONUS">
-			<Text>Você não é a nação mais favorecida de {1_CivName:textkey}... Com isso, eles irão deixar de lhe conceder recursos estratégicos e de luxo.</Text>
+			<Text>Você não é a nação mais favorecida {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}... Com isso, eles irão deixar de lhe conceder recursos estratégicos e de luxo.</Text>
 		</Row>
 		<!-- Other Notifications -->
 		<Row Tag="TXT_KEY_NOTIFICATION_NEW_RESEARCH">
 			<Text>Você pode selecionar um novo projeto de pesquisa.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_NEW_CONSTRUCTION">
-			<Text>{1_CivName} está pronta para um novo projeto de construção.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} está pronta para um novo projeto de construção.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_PLAYER_LOST_CAPITAL">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {@1_CivName} {1: plural 1?perdeu; other?perderam;} sua [ICON_CAPITAL]Capital! {2_NumPlayers} {2: plural 1?Civilização continua; other?Civilizações continuam;} em posse {2: plural 1?da sua [ICON_CAPITAL]Capital; other?das suas [ICON_CAPITAL]Capitais;}.</Text>
+			<Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_CivName} {@1: plural 1?perdeu; other?perderam;} sua [ICON_CAPITAL]Capital! {2_NumPlayers} {2: plural 1?Civilização continua; other?Civilizações continuam;} em posse {2: plural 1?da sua [ICON_CAPITAL]Capital; other?das suas [ICON_CAPITAL]Capitais;}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_PLAYER_RECOVERED_CAPITAL">
-			<Text>{@1_CivName} {1: plural 1?recuperou; other?recuperaram;} sua [ICON_CAPITAL]Capital!</Text>
+			<Text>{@1: gender *:noart?{}; feminine?{@1: plural 2?As ; other?A ;}; masculine?{@1: plural 2?Os ; other?O ;}; other?{};}{@1_CivName} {@1: plural 1?recuperou; other?recuperaram;} sua [ICON_CAPITAL]Capital!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SOMEONE_LOST_CAPITAL">
 			<Text>Uma Civilização desconhecida perdeu sua [ICON_CAPITAL]Capital! {1_NumPlayers} {1: plural 1?Civilização continua; other?Civilizações continuam;}; feminine?{1: plural 1?a; other?as;};} em posse {1: plural 1?da sua [ICON_CAPITAL]Capital; other?das suas [ICON_CAPITAL]Capitais;}.</Text>
@@ -844,22 +844,22 @@
 			<Text>Uma Civilização desconhecida recuperou sua [ICON_CAPITAL]Capital!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_WONDER_STARTED">
-			<Text>{1_CivName} {1: plural 1?iniciou; other?iniciaram;} a construção de {2: gender masculine?um; feminine?uma;} {2_BldgName} em {3_CityName:textkey}.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} {1: plural 1?iniciou; other?iniciaram;} a construção de {2: gender masculine?um; feminine?uma;} {2_BldgName} em {3_CityName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_WONDER_STARTED_UNKNOWN_LOCATION">
-			<Text>{1_CivName} {1: plural 1?iniciou; other?iniciaram;} a construção de {2: gender masculine?um; feminine?uma;} {2_BldgName}.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} {1: plural 1?iniciou; other?iniciaram;} a construção de {2: gender masculine?um; feminine?uma;} {2_BldgName}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_WONDER_STARTED_UNMET">
 			<Text>Uma Civilização desconhecida iniciou a construção de {1: gender masculine?um; feminine?uma;} {1_BldgName}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_GOLDEN_AGE_BEGUN">
-			<Text>Teve início a Era Dourada para a Civilização {1_LongCivName:textkey}.</Text>
+			<Text>Teve início a Era Dourada para a Civilização {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_LongCivName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_GOLDEN_AGE_BEGUN_ACTIVE_PLAYER">
 			<Text>A Era dourada iniciou para você!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_GOLDEN_AGE_ENDED">
-			<Text>A Era Dourada para {1: gender *:noart? ; masculine?{1: plural 1?o; other?os;}; feminine?{1: plural 1?a; other?as;};} {1_LongCivName:textkey} terminou.</Text>
+			<Text>A Era Dourada para {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_LongCivName:textkey} terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_GOLDEN_AGE_ENDED_ACTIVE_PLAYER">
 			<Text>A sua Era Dourada terminou.</Text>
@@ -868,31 +868,31 @@
 			<Text>Uma unidade adquiriu experiência suficiente para ser promovida.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_CATEGORY_FIRST_PLACE">
-			<Text>{1_CivName:textkey} {1: plural 1?ganhou; other?ganharam;} o PRIMEIRO lugar na Era {2_Era:textkey} com {3_Victory:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?ganhou; other?ganharam;} o PRIMEIRO lugar na Era {2_Era:textkey} com {3_Victory:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_CATEGORY_FIRST_PLACE_YOU">
 			<Text>Você ganhou em PRIMEIRO lugar na Era {2_Era:textkey} com {3_Victory:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_CATEGORY_FOURTH_PLACE">
-			<Text>{1_CivName:textkey} {1: plural 1?ficou; other?ficaram;} em QUARTO lugar na Era {2_Era:textkey} com {3_Victory:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?ficou; other?ficaram;} em QUARTO lugar na Era {2_Era:textkey} com {3_Victory:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_CATEGORY_FOURTH_PLACE_YOU">
 			<Text>Você ficou em QUARTO lugar na Era {2_Era:textkey} com {3_Victory:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_CATEGORY_SECOND_PLACE">
-			<Text>{1_CivName:textkey} {1: plural 1?ficou; other?ficaram;} em SEGUNDO lugar na Era {2_Era:textkey} com {3_Victory:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?ficou; other?ficaram;} em SEGUNDO lugar na Era {2_Era:textkey} com {3_Victory:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_CATEGORY_SECOND_PLACE_YOU">
 			<Text>Você ficou em SEGUNDO lugar na Era {2_Era:textkey} com {3_Victory:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_CATEGORY_THIRD_PLACE">
-			<Text>{1_CivName:textkey} {1: plural 1?ficou; other?ficaram;} em TERCEIRO lugar na era {2_Era:textkey} com {3_Victory:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?ficou; other?ficaram;} em TERCEIRO lugar na era {2_Era:textkey} com {3_Victory:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_CATEGORY_THIRD_PLACE_YOU">
 			<Text>Você ficou em TERCEIRO lugar na Era {2_Era:textkey} com {3_Victory:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_RACE_WON_SOMEBODY">
-			<Text>{1_CivName:textkey} {1: gender masculine?{1: plural 1?foi classificado; other?foram classificados;}; feminine?{1: plural 1?foi classificada; other?foram classificadas;};} em #{2_Rank} na competição por {3_Victory:textkey}, e {1: plural 1?ganhou; other?ganharam;} {4_Num} {4: plural 1?ponto; other?pontos;} de Civilização!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: gender masculine?{1: plural 1?foi classificado; other?foram classificados;}; feminine?{1: plural 1?foi classificada; other?foram classificadas;};} em #{2_Rank} na competição por {3_Victory:textkey}, e {1: plural 1?ganhou; other?ganharam;} {4_Num} {4: plural 1?ponto; other?pontos;} de Civilização!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_RACE_WON_UNMET">
 			<Text>Um jogador desconhecido foi classificado em #{1_Rank} na competição por {2_Victory:textkey} e ganhou {3_Num} {3: plural 1?ponto; other?pontos;} de Civilização!</Text>
@@ -901,7 +901,7 @@
 			<Text>Você foi classificado em #{1_Rank} na Competição por {2_Victory:textkey} e ganhou {3_Num} {3: plural 1?ponto; other?pontos;} de Civilização!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_VICTORY_WINNER">
-			<Text>{1_CivName:textkey} {1: plural 1?ganhou; other?ganharam;} o jogo por meio da Vitória {2_Victory:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?ganhou; other?ganharam;} o jogo por meio da Vitória {2_Victory:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_YOU_LOST_CAPITAL">
 			<Text>Você perdeu sua [ICON_CAPITAL]Capital! {1_NumPlayers} {1: plural 1?continua em posse da sua [ICON_CAPITAL]Capital; other?continuam em posse das suas [ICON_CAPITAL]Capitais;}.</Text>
@@ -910,13 +910,13 @@
 			<Text>Você recuperou sua [ICON_CAPITAL]Capital!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DIPLOMACY_DECLARATION">
-			<Text>Declaração pública {1: gender *:noart?de; masculine?{1: plural 1?do; other?dos;}; feminine?{1: plural 1?da; other?das;};} {1_CivName:textkey}</Text>
+			<Text>Declaração pública {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_RESEARCH_AGREEMENT">
-			<Text>{1_CivName:textkey} e {2_CivName:textkey} assinaram um acordo de pesquisa!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} e {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey} assinaram um acordo de pesquisa!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_GREAT_PERSON">
-			<Text>Uma Grande Pessoa nasceu {1: gender *:noart?em; masculine?{1: plural 1?no; other?nos;}; feminine?{1: plural 1?na; other?nas;};} {1_CivName:textkey}.</Text>
+			<Text>Uma Grande Pessoa nasceu {1: gender *:noart?em; feminine?{1: plural 2?nas; other?na;}; masculine?{1: plural 2?nos; other?no;}; other?em;} {1_CivName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_GREAT_PERSON_ACTIVE_PLAYER">
 			<Text>Uma Grande Pessoa nasceu em sua Civilização!</Text>
@@ -925,10 +925,10 @@
 			<Text>Uma Grande Pessoa nasceu em uma terra distante!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CITY_LOST">
-			<Text>{1_CityName:textkey} foi capturada {2: gender masculine?{2: plural 1?pelo; other?pelos;}; feminine?{2: plural 1?pela; other?pelas;};} {@2_CivName}!</Text>
+			<Text>{1_CityName:textkey} foi capturada {@2: gender *:noart?por; feminine?{@2: plural 2?pelas; other?pela;}; masculine?{@2: plural 2?pelos; other?pelo;}; other?por;} {@2_CivName}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_BEST_IN_GREAT_PEOPLE_ANOTHER">
-			<Text>{1_CivName:textkey} {1: plural 1?possui; other?possuem;} a maioria das Grandes Pessoas</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?possui; other?possuem;} a maioria das Grandes Pessoas</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_BEST_IN_GREAT_PEOPLE_UNMET">
 			<Text>Um jogador desconhecido possui a maioria das Grandes Pessoas</Text>
@@ -937,7 +937,7 @@
 			<Text>Você possui a maioria das Grandes Pessoas!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_BEST_IN_POLICIES_ANOTHER">
-			<Text>{1_CivName:textkey} tem a maioria das Políticas</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} tem a maioria das Políticas</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_BEST_IN_POLICIES_UNMET">
 			<Text>Um jogador desconhecido tem a maioria das Políticas</Text>
@@ -946,7 +946,7 @@
 			<Text>Você possui a maioria das Políticas Sociais!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_BEST_IN_WONDERS_ANOTHER">
-			<Text>{1_CivName:textkey} {1: plural 1?possui; other?possuem;} a maioria das Maravilhas</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?possui; other?possuem;} a maioria das Maravilhas</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_BEST_IN_WONDERS_UNMET">
 			<Text>Um jogador desconhecido possui a maioria das Maravilhas</Text>
@@ -961,40 +961,40 @@
 			<Text>{1_CityName:textkey} {1: plural 1?cresceu; other?cresceram;}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_DEFENSIVE_PACT_FROM_US">
-			<Text>O pacto defensivo realizado com {1_CivName:textkey} terminou</Text>
+			<Text>O pacto defensivo realizado com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_DEFENSIVE_PACT_TO_US">
-			<Text>O pacto defensivo realizado com {1_CivName:textkey} terminou</Text>
+			<Text>O pacto defensivo realizado com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_GPT_FROM_US">
-			<Text>O acordo que dava Ouro/turno para {1_CivName:textkey} terminou</Text>
+			<Text>O acordo que dava Ouro/turno para {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_GPT_TO_US">
-			<Text>O acordo que recebia Ouro/turno {1: gender *:noart?de; masculine?{1: plural 1?do; other?dos;}; feminine?{1: plural 1?da; other?das;};} {1_CivName:textkey} terminou</Text>
+			<Text>O acordo que recebia Ouro/turno {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_OPEN_BORDERS_FROM_US">
-			<Text>O acordo de fronteiras abertas para {1_CivName:textkey} terminou</Text>
+			<Text>O acordo de fronteiras abertas para {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_OPEN_BORDERS_TO_US">
-			<Text>O acordo de fronteiras abertas {1: gender *:noart?de; masculine?{1: plural 1?do; other?dos;}; feminine?{1: plural 1?da; other?das;};} {1_CivName:textkey} terminou</Text>
+			<Text>O acordo de fronteiras abertas {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_RESEARCH_AGREEMENT_FROM_US">
-			<Text>O acordo de pesquisa que fizemos com {1_CivName:textkey} terminou</Text>
+			<Text>O acordo de pesquisa que fizemos com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_RESEARCH_AGREEMENT_TO_US">
-			<Text>O acordo de pesquisa feito {1: gender *:noart?por; masculine?{1: plural 1?pelo; other?pelos;}; feminine?{1: plural 1?pela; other?pelas;};} {1_CivName:textkey} terminou</Text>
+			<Text>O acordo de pesquisa feito {1: gender *:noart?por; feminine?{1: plural 2?pelas; other?pela;}; masculine?{1: plural 2?pelos; other?pelo;}; other?por;} {1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_RESOURCE_FROM_US">
-			<Text>{2_Resource} para {1_CivName:textkey} terminou</Text>
+			<Text>{2_Resource} para {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_RESOURCE_TO_US">
-			<Text>{2_Resource} {2: gender masculine?{2: plural 1?vindo; other?vindos;}; feminine?{2: plural 1?vinda; other?vindas;};} {1: gender *:noart?de; masculine?{1: plural 1?do; other?dos;}; feminine?{1: plural 1?da; other?das;};} {1_CivName:textkey} terminou</Text>
+			<Text>{2_Resource} {2: gender masculine?{2: plural 1?vindo; other?vindos;}; feminine?{2: plural 1?vinda; other?vindas;};} {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_TRADE_AGREEMENT_FROM_US">
-			<Text>O acordo comercial que fizemos com {1_CivName:textkey} terminou</Text>
+			<Text>O acordo comercial que fizemos com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DEAL_EXPIRED_TRADE_AGREEMENT_TO_US">
-			<Text>O acordo comercial feito por {1_CivName:textkey} terminou</Text>
+			<Text>O acordo comercial feito {1: gender *:noart?por; feminine?{1: plural 2?pelas; other?pela;}; masculine?{1: plural 2?pelos; other?pelo;}; other?por;} {1_CivName:textkey} terminou</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_ENOUGH_CULTURE_FOR_POLICY">
 			<Text>Você pode adotar uma política</Text>
@@ -1024,52 +1024,52 @@
 			<Text>{1_ResourceName:textkey} {1: gender masculine?{1: plural 1?descoberto; other?descobertos;}; feminine?{1: plural 1?descoberta; other?descobertas;};}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MET_MINOR_CIV">
-			<Text>Você conheceu {1_CivName:textkey}</Text>
+			<Text>Você conheceu {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_FRIENDS_STATUS">
-			<Text>{1_CivName:textkey} {1: gender masculine?{1: plural 1?é nosso amigo; other?são nossos amigos;}; feminine?{1: plural 1?é nossa amiga; other?são nossas amigas;};} agora!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: gender masculine?{1: plural 1?é nosso amigo; other?são nossos amigos;}; feminine?{1: plural 1?é nossa amiga; other?são nossas amigas;};} agora!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_FRIENDS_STATUS_LOST">
-			<Text>{1_CivName:textkey} não {1: plural 2?são; other?é;} mais {1: gender *:noart?nossa amiga; feminine?{1: plural 2?nossas amigas; other?nossa amiga;}; masculine?{1: plural 2?nossos amigos; other?nosso amigo;}; other?nossas amigas;}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} não {1: plural 2?são; other?é;} mais {1: gender *:noart?nossa amiga; feminine?{1: plural 2?nossas amigas; other?nossa amiga;}; masculine?{1: plural 2?nossos amigos; other?nosso amigo;}; other?nossas amigas;}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_ALLIES_STATUS">
-			<Text>Agora somos aliados de {1_CivName:textkey}!</Text>
+			<Text>Agora somos aliados {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_ALLIES_STATUS_LOST">
 			<Text>{1: gender *:noart? ; feminine?{1: plural 2?As; other?A;}; masculine?{1: plural 2?Os; other?O;}; other? ;} {1_CivName:textkey} não {1: plural 2?são; other?é;} mais {1: gender *:noart?nossa aliada; feminine?{1: plural 2?nossas aliadas; other?nossa aliada;}; masculine?{1: plural 2?nossos aliados; other?nosso aliado;}; other?nossa aliada;}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_ALLIES_STATUS_PASSED">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {1_CivName:textkey} agora {1: gender masculine?{1: plural 1?é aliado; other?são aliados;}; feminine?{1: plural 1?é aliada; other?são aliadas;};} {2: gender *:noart?de; masculine?{2: plural 1?do; other?dos;}; feminine?{2: plural 1?da; other?das;};} {2_MinorCivName:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} agora {1: gender masculine?{1: plural 1?é aliado; other?são aliados;}; feminine?{1: plural 1?é aliada; other?são aliadas;};} {2: gender *:noart?de; feminine?{2: plural 2?das; other?da;}; masculine?{2: plural 2?dos; other?do;}; other?de;} {2_MinorCivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_GAINED_BEST_RELATIONS_BONUS">
-			<Text>Status favorecido com {1_CivName:textkey}</Text>
+			<Text>Status favorecido com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_INTRUSION">
-			<Text>Você transpassou as fronteiras {1: gender *:noart?de; masculine?{1: plural 1?do; other?dos;}; feminine?{1: plural 1?de; other?das;};} {1_CivName:textkey}!</Text>
+			<Text>Você transpassou as fronteiras {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_LIBERATION">
-			<Text>{1_CivName:textkey} {1: gender masculine?{1: plural 1?libertado; other?libertados;}; feminine?{1: plural 1?libertada; other?libertadas;};}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: gender masculine?{1: plural 1?libertado; other?libertados;}; feminine?{1: plural 1?libertada; other?libertadas;};}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_MINOR_LOST_BEST_RELATIONS_BONUS">
-			<Text>Status Favorecido com {1_CivName:textkey} foi perdido</Text>
+			<Text>Status Favorecido com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} foi perdido</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_CITY_STATE_ALMOST_NOT_FRIENDS">
-			<Text>Sua [ICON_INFLUENCE]Influência sobre {1_CivName:textkey} caiu tanto ao ponto de não serem mais amigos!</Text>
+			<Text>Sua [ICON_INFLUENCE]Influência sobre {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} caiu tanto ao ponto de não serem mais amigos!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_CITY_STATE_ALMOST_NOT_ALLIES">
-			<Text>Sua [ICON_INFLUENCE]Influência sobre {1_CivName:textkey} caiu tanto ao ponto de não serem mais aliados!</Text>
+			<Text>Sua [ICON_INFLUENCE]Influência sobre {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} caiu tanto ao ponto de não serem mais aliados!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_CITY_STATE_ALMOST_SM">
-			<Text>Perdendo contato com {1_CivName:textkey}!</Text>
+			<Text>Perdendo contato com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_NEW_RESEARCH">
 			<Text>Escolha uma nova pesquisa</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_PLAYER_LOST_CAPITAL">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {1_CivName:textkey} {1: plural 1?perdeu; other?perderam;} sua [ICON_CAPITAL]Capital</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?perdeu; other?perderam;} sua [ICON_CAPITAL]Capital</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_PLAYER_RECOVERED_CAPITAL">
-			<Text>{1_CivName:textkey} {1: plural 1?recuperou; other?recuperaram;} sua [ICON_CAPITAL]Capital</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?recuperou; other?recuperaram;} sua [ICON_CAPITAL]Capital</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_SOMEONE_LOST_CAPITAL">
 			<Text>Um jogador desconhecido perdeu sua [ICON_CAPITAL]Capital</Text>
@@ -1081,31 +1081,31 @@
 			<Text>Unidade promovida</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_CATEGORY_FIRST_PLACE">
-			<Text>{1_CivName:textkey} {1: plural 1?está; other?estão;} em 1º lugar nesta Era</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?está; other?estão;} em 1º lugar nesta Era</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_CATEGORY_FIRST_PLACE_YOU">
 			<Text>1º lugar nesta Era</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_CATEGORY_FOURTH_PLACE">
-			<Text>{1_CivName:textkey} {1: plural 1?está; other?estão;} em 4º lugar nesta Era</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?está; other?estão;} em 4º lugar nesta Era</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_CATEGORY_FOURTH_PLACE_YOU">
 			<Text>4º lugar nesta Era</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_CATEGORY_SECOND_PLACE">
-			<Text>{1_CivName:textkey} {1: plural 1?está; other?estão;} em 2º nesta Era</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?está; other?estão;} em 2º nesta Era</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_CATEGORY_SECOND_PLACE_YOU">
 			<Text>2º lugar nesta Era</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_CATEGORY_THIRD_PLACE">
-			<Text>{1_CivName:textkey} {1: plural 1?está; other?estão;} em 3º nesta Era</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?está; other?estão;} em 3º nesta Era</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_CATEGORY_THIRD_PLACE_YOU">
 			<Text>3º nesta Era</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_RACE_WON_SOMEBODY">
-			<Text>{1_CivName:textkey} {1: gender masculine?{1: plural 1?está classificado; other?estão classificados;}; feminine?{1: plural 1?está classificada; other?estão classificadas;};} em #{2_Rank} na {3_Victory:textkey}</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: gender masculine?{1: plural 1?está classificado; other?estão classificados;}; feminine?{1: plural 1?está classificada; other?estão classificadas;};} em #{2_Rank} na {3_Victory:textkey}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_RACE_WON_UNMET">
 			<Text>Um jogador desconhecido está classificado em #{1_Rank} na {2_Victory:textkey}</Text>
@@ -1114,7 +1114,7 @@
 			<Text>#{1_Rank} {1: gender masculine?{1: plural 1?classificado; other?classificados;}; feminine?{1: plural 1?classificada; other?classificadas;};} na {2_Victory:textkey}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_VICTORY_WINNER">
-			<Text>{1_CivName:textkey} {1: plural 1?venceu; other?venceram;}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?venceu; other?venceram;}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_YOU_LOST_CAPITAL">
 			<Text>Sua [ICON_CAPITAL]Capital foi perdida!</Text>
@@ -1213,19 +1213,19 @@
 			<Text>Uma Grande Pessoa nasceu</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_WONDER_STARTED">
-			<Text>{1_CivName} iniciou a construção de {2_BldgName}.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName} iniciou a construção de {2_BldgName}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_WONDER_STARTED_UNKNOWN">
 			<Text>Um jogador desconhecido iniciou a construção de {1_BldgName}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_GOLDEN_AGE_BEGUN">
-			<Text>A Era Dourada {1: gender *:noart?de; masculine?{1: plural 1?do; other?dos;}; feminine?{1: plural 1?da; other?das;};} {1_CivName:textkey} iniciou.</Text>
+			<Text>A Era Dourada {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} iniciou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_GOLDEN_AGE_BEGUN_ACTIVE_PLAYER">
 			<Text>Uma Era Dourada surgiu!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_GOLDEN_AGE_ENDED">
-			<Text>A Era Dourada {1: gender *:noart?de; masculine?{1: plural 1?do; other?dos;}; feminine?{1: plural 1?da; other?das;};} {1_CivName:textkey} terminou.</Text>
+			<Text>A Era Dourada {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} terminou.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_GOLDEN_AGE_ENDED_ACTIVE_PLAYER">
 			<Text>Sua Era Dourada terminou.</Text>
@@ -1240,10 +1240,10 @@
 			<Text>[ICON_INFLUENCE]Influência sobre Cidade-Estado alterada!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_GREAT_ARTIST_STOLE_PLOT">
-			<Text>{1_CivName:textkey} {1: plural 1?roubou; other?roubaram;} algum terreno seu!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?roubou; other?roubaram;} algum terreno seu!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_GREAT_ARTIST_STOLE_PLOT">
-			<Text>{1_CivName:textkey} {1: plural 1?usou; other?usaram;} um Grande Artista para roubar algum terreno seu!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1: plural 1?usou; other?usaram;} um Grande Artista para roubar algum terreno seu!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_TRADE_ROUTE_ESTABLISHED">
 			<Text>[ICON_CONNECTED]Rota comercial estabilizada!</Text>
@@ -3087,28 +3087,28 @@
 			<Text>Denunciado por {1_PlayerName}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DOF">
-			<Text>{1_CivName:textkey} e {2_CivName:textkey} fizeram uma Declaração de Amizade pública, construindo um forte laço entre os dois Impérios.</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} e {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey} fizeram uma Declaração de Amizade pública, construindo um forte laço entre os dois Impérios.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DOF_S">
-			<Text>{1_CivName:textkey} e {2_CivName:textkey} agora são {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} e {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey} agora são {1: gender feminine?{2: gender feminine?amigas; other?amigos;}; other?amigos;}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DENOUNCE">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {1_CivName:textkey} {@1_CivName: plural 1?denunciou; other?denunciaram;} publicamente {2: plural 1?{2: gender *:noart? ; feminine?a; masculine?o; other? ;}; other?{2: gender *:noart? ; feminine?as; masculine?os; other? ;};} {2_CivName:textkey}, avisando ao mundo que eles não são confiáveis!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1_CivName: plural 1?denunciou; other?denunciaram;} publicamente {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey}, avisando ao mundo que eles não são confiáveis!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DENOUNCE_S">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {1_CivName:textkey} {@1_CivName: plural 1?denunciou; other?denunciaram;} {2: plural 1?{2: gender *:noart? ; feminine?a; masculine?o; other? ;}; other?{2: gender *:noart? ; feminine?as; masculine?os; other? ;};} {2_CivName:textkey}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} {1_CivName: plural 1?denunciou; other?denunciaram;} {2: gender *:noart?{}; feminine?{2: plural 2?as ; other?a ;}; masculine?{2: plural 2?os ; other?o ;}; other?{};}{2_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_YOU_DENOUNCE">
-			<Text>Você denunciou publicamente {1: plural 1?{1: gender *:noart? ; feminine?a; masculine?o; other? ;}; other?{1: gender *:noart? ; feminine?as; masculine?os; other? ;};} {1_CivName:textkey}, avisando ao mundo que eles não são confiáveis!</Text>
+			<Text>Você denunciou publicamente {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}, avisando ao mundo que eles não são confiáveis!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_YOU_DENOUNCE_S">
-			<Text>Você denunciou {1: plural 1?{1: gender *:noart? ; feminine?a; masculine?o; other? ;}; other?{1: gender *:noart? ; feminine?as; masculine?os; other? ;};} {1_CivName:textkey}!</Text>
+			<Text>Você denunciou {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DENOUNCE_YOU">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {1_CivName:textkey} te {@1_CivName: plural 1?denunciou; other?denunciaram;} publicamente, avisando ao mundo que você não é confiável!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} te {1_CivName: plural 1?denunciou; other?denunciaram;} publicamente, avisando ao mundo que você não é confiável!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DENOUNCED_YOU_S">
-			<Text>{1: plural 1?{1: gender *:noart? ; feminine?A; masculine?O; other? ;}; other?{1: gender *:noart? ; feminine?As; masculine?Os; other? ;};} {1_CivName:textkey} te {@1_CivName: plural 1?denunciou; other?denunciaram;}!</Text>
+			<Text>{1: gender *:noart?{}; feminine?{1: plural 2?As ; other?A ;}; masculine?{1: plural 2?Os ; other?O ;}; other?{};}{1_CivName:textkey} te {1_CivName: plural 1?denunciou; other?denunciaram;}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_THEIR_DENUNCIATION_EXPIRED">
 		  <Text>O fato de você ter sido denunciado por {1_LeaderName} não influencia em nada nas relações com os outros líderes.</Text>
@@ -3297,13 +3297,13 @@
 			<Text>Retirar</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_FRIENDS_WITH">
-			<Text>[COLOR_POSITIVE_TEXT]Amigos de {1_CivName:textkey}[ENDCOLOR]</Text>
+			<Text>[COLOR_POSITIVE_TEXT]Amigos {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey}[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_DENOUNCED">
-			<Text>[COLOR_NEGATIVE_TEXT]Denunciou {1_CivName:textkey}[ENDCOLOR]</Text>
+			<Text>[COLOR_NEGATIVE_TEXT]Denunciou {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_BACKSTABBED">
-			<Text>[COLOR_NEGATIVE_TEXT]Traiu {1_CivName:textkey}[ENDCOLOR]</Text>
+			<Text>[COLOR_NEGATIVE_TEXT]Traiu {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey}[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_YOU_HAVE_DENOUNCED">
 			<Text>[COLOR_NEGATIVE_TEXT]DENUNCIADO[ENDCOLOR]</Text>
@@ -3357,7 +3357,7 @@
 		</Row>
 		<!-- 511 -->
 		<Row Tag="TXT_KEY_NTFN_RA_FREE_TECH_CANCEL">
-			<Text>O seu Acordo de Pesquisa com {1_CivName:textkey} foi cancelado.</Text>
+			<Text>O seu Acordo de Pesquisa com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName:textkey} foi cancelado.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NTFN_RA_FREE_TECH_CANCEL_S">
 			<Text>Acordo de Pesquisa Cancelado!</Text>

--- a/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_WorldView.xml
+++ b/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_WorldView.xml
@@ -185,7 +185,7 @@
 			<Text>{1_Num} HP</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PLOTROLL_OWNED_CIV">
-			<Text>Ladrilho adquirido {2_CivName: gender masculine?{2_CivName: plural 1?pelo; other?pelos;}; feminine?{2_CivName: plural 1?pela; other?pelas;};} {1_CivName:textkey}</Text>
+			<Text>Ladrilho adquirido {1: gender *:noart?por; feminine?{1: plural 2?pelas; other?pela;}; masculine?{1: plural 2?pelos; other?pelo;}; other?por;} {1_CivName:textkey}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PLOTROLL_OWNED_PLAYER">
 			<Text>Ladrilho adquirido por {1_PlayerName}</Text>
@@ -236,7 +236,7 @@
 			<Text>Missão de Cidade-Estado</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_STATE_BARB_QUEST_LONG">
-			<Text>A Cidade-Estado de {1_CivName:textkey} quer que você destrua o acampamento bárbaro neste hexágono.</Text>
+			<Text>A Cidade-Estado {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName:textkey} quer que você destrua o acampamento bárbaro neste hexágono.</Text>
 		</Row>
 		<!-- Unit Panel Texts -->
 		<Row Tag="TXT_KEY_UPANEL_HEALTH">
@@ -1039,7 +1039,7 @@
 		</Row>		
 		<!-- 2.13 -->
 		<Row Tag="TXT_KEY_PROCESSING_TURN_FOR">
-		  <Text>Processando turno de {1_CivilizationName}</Text>
+		  <Text>Processando turno {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;} {1_CivilizationName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PROCESSING_MINOR_CIVS">
 		  <Text>Processando turno das Cidades-Estado</Text>

--- a/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_WorldView.xml
+++ b/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_WorldView.xml
@@ -1039,7 +1039,7 @@
 		</Row>		
 		<!-- 2.13 -->
 		<Row Tag="TXT_KEY_PROCESSING_TURN_FOR">
-		  <Text>Processando turno {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;} {1_CivilizationName}</Text>
+		  <Text>Processando turno {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivilizationName}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PROCESSING_MINOR_CIVS">
 		  <Text>Processando turno das Cidades-Estado</Text>

--- a/Assets/Gameplay/XML/NewText/PT_BR/LeaderDialog/Civ5_Dialog__GENERIC.xml
+++ b/Assets/Gameplay/XML/NewText/PT_BR/LeaderDialog/Civ5_Dialog__GENERIC.xml
@@ -8,7 +8,7 @@
 		  <Text>Fui informado que você tem um grande número de unidades perto das minhas fronteiras. Eu peço que você as leve para outro lugar para evitar desconforto desnecessário aos nossos cidadãos.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ATTACKED_PROTECTED_CITY_STATE_1">
-		  <Text>Seus ataques injustificados à {@1_MinorCivName} não passaram despercebidos. Pare com isso ou corra o risco de sofrer sérias consequências.</Text>
+		  <Text>Seus ataques injustificados {@1: gender *:noart?a; feminine?{@1: plural 2?às; other?à;}; masculine?{@1: plural 2?aos; other?ao;}; other?a;} {@1_MinorCivName} não passaram despercebidos. Pare com isso ou corra o risco de sofrer sérias consequências.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_COOP_WAR_REQUEST_1">
 		  <Text>Minhas diferenças com {1_PlayerName:textkey} já são intransponíveis. É uma situação que só pode ser resolvida no campo de batalha. Você vai se juntar a mim, camarada?</Text>
@@ -185,10 +185,10 @@
 		  <Text>Se você está tentando provocar uma guerra, você está conseguindo.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_GENERIC_DECLARATION_ABANDON_CITY_STATE_1">
-		  <Text>{2: plural 1?{2: gender masculine?O; feminine?A;}; other?{2: gender masculine?Os; feminine?As;};} {2_MajorCivName:textkey} {2: plural 1?retirou; other?retiraram;} a sua garantia de proteger {1_MinorCivName:textkey}.</Text>
+		  <Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};} {2_MajorCivName:textkey} {2: plural 1?retirou; other?retiraram;} a sua garantia de proteger {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_MinorCivName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_GENERIC_DECLARATION_PROTECT_CITY_STATE_1">
-		  <Text>{2: plural 1?{2: gender masculine?O; feminine?A;}; other?{2: gender masculine?Os; feminine?As;};} {2_MajorCivName:textkey} {2: plural 1?anuncia; other?anunciam;} ao mundo que agora {2: plural 1?está; other?estão;} protegendo {1_MinorCivName:textkey}.</Text>
+		  <Text>{2: gender *:noart?{}; feminine?{2: plural 2?As ; other?A ;}; masculine?{2: plural 2?Os ; other?O ;}; other?{};} {2_MajorCivName:textkey} {2: plural 1?anuncia; other?anunciam;} ao mundo que agora {2: plural 1?está; other?estão;} protegendo {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_MinorCivName:textkey}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_GENERIC_DECLINE_1">
 		  <Text>Devo rejeitar</Text>
@@ -653,10 +653,10 @@
 		  <Text>Você tem um recurso de luxo que me interessa. O que você acha desta oferta?</Text>
 		</Row>
 		<Row Tag="TXT_KEY_GENERIC_MINOR_CIV_COMPETITION_1">
-		  <Text>Foi-me dito que você está fazendo amizade com {1_MinorCivName:textkey}. Caso você não saiba, eles estão na minha área de influência e prefiro que você fique longe dela.</Text>
+		  <Text>Foi-me dito que você está fazendo amizade com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_MinorCivName:textkey}. Caso você não saiba, eles estão na minha área de influência e prefiro que você fique longe dela.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_GENERIC_MINOR_CIV_COMPETITION_2">
-		  <Text>Percebi que você tem uma relação com {1_MinorCivName:textkey}. Embora isso seja bom, seria melhor que deixasse a proteção deles em nossas mãos. Seria bom começar a preservar os outros.</Text>
+		  <Text>Percebi que você tem uma relação com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_MinorCivName:textkey}. Embora isso seja bom, seria melhor que deixasse a proteção deles em nossas mãos. Seria bom começar a preservar os outros.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_GENERIC_NO_PEACE_1">
 		  <Text>Não pode haver paz. Talvez outro dia.</Text>
@@ -1104,10 +1104,10 @@
  			<Text>Fazer uma declaração como essa neste ponto da nossa relação seria prematuro. Talvez em outro momento.</Text>
  		</Row>
  		<Row Tag="TXT_KEY_DOF_AI_DENOUNCE_REQUEST_1">
- 			<Text>Amigo, eu tenho assuntos sérios para discutir. Minha relação com {1_CivName} acabou e eu preciso que você os denuncie como um ato de apoio. O que você diz?</Text>
+			<Text>Amigo, eu tenho assuntos sérios para discutir. Minha relação com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName} acabou e eu preciso que você os denuncie como um ato de apoio. O que você diz?</Text>
  		</Row>
  		<Row Tag="TXT_KEY_DOF_AI_WAR_REQUEST_1">
- 			<Text>Eu me encontro em uma situação muito séria, meu amigo. O tempo da guerra contra {1_CivName} e eu preciso que você se junte a mim no campo de batalha. O que você diz? (IRÁ DECLARAR GUERRA IMEDITAMENTE)</Text>
+			<Text>Eu me encontro em uma situação muito séria, meu amigo. O tempo da guerra contra {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName} e eu preciso que você se junte a mim no campo de batalha. O que você diz? (IRÁ DECLARAR GUERRA IMEDITAMENTE)</Text>
  		</Row>
  		<Row Tag="TXT_KEY_DOF_NOT_HONORED_1">
  			<Text>Patético. Enfim você exibiu sua verdadeira forma. O mundo conhecerá sua desonra.[NEWLINE][NEWLINE]([COLOR_WARNING_TEXT]Eles nos denunciaram publicamente! NOTA: Você não está em guerra.[ENDCOLOR])</Text>
@@ -1134,28 +1134,28 @@
  			<Text>Eu tinha o sentimento que estava perdendo meu tempo com você. Entretanto, eu já sabia que isso iria ocorrer.</Text>
  		</Row>
  		<Row Tag="TXT_KEY_HUMAN_DOFED_FRIEND_1">
- 			<Text>Ahh, eu percebi que você se tornou amigo {1: gender feminine?{1: plural 1?da; other?das;}; other?{1: plural 1?do; other?dos;};} {1_CivName}. Bom saber disso. Eu já tenho um bom relacionamento com eles.</Text>
+			<Text>Ahh, eu percebi que você se tornou amigo {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName}. Bom saber disso. Eu já tenho um bom relacionamento com eles.</Text>
  		</Row>
  		<Row Tag="TXT_KEY_HUMAN_DOFED_ENEMY_1">
- 			<Text>Eu recomento que você não se aproxime muito {1: gender feminine?{1: plural 1?da; other?das;}; other?{1: plural 1?do; other?dos;};} {1_CivName}. Se o fizer, nós poderemos ter problemas no futuro.</Text>
+			<Text>Eu recomento que você não se aproxime muito {1: gender *:noart?de; feminine?{1: plural 2?das; other?da;}; masculine?{1: plural 2?dos; other?do;}; other?de;} {1_CivName}. Se o fizer, nós poderemos ter problemas no futuro.</Text>
  		</Row>
  		<Row Tag="TXT_KEY_HUMAN_DENOUNCED_FRIEND_1">
- 			<Text>Gostaria que você soubesse que {1_CivName} e eu já trabalhamos juntos no passado e eu tenho o maior respeito por eles. Então, você está avisado.</Text>
+			<Text>Gostaria que você soubesse que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName} e eu já trabalhamos juntos no passado e eu tenho o maior respeito por eles. Então, você está avisado.</Text>
  		</Row>
  		<Row Tag="TXT_KEY_HUMAN_DENOUNCED_ENEMY_1">
- 			<Text>Que bom saber que há outros no mundo que compartilham do meu desgosto para com {1_CivName}. Certamente eles não são confiáveis.</Text>
+			<Text>Que bom saber que há outros no mundo que compartilham do meu desgosto para com {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName}. Certamente eles não são confiáveis.</Text>
  		</Row>
  		<Row Tag="TXT_KEY_HUMAN_DOF_SO_AI_DOF_1">
- 			<Text>Eu não pude deixar de notar que você e {1_CivName} se tornaram amigos. Eu fiz o mesmo. Talvez a construção dessa aliança nos leve a grandes coisas no futuro.</Text>
+			<Text>Eu não pude deixar de notar que você e {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName} se tornaram amigos. Eu fiz o mesmo. Talvez a construção dessa aliança nos leve a grandes coisas no futuro.</Text>
  		</Row>
  		<Row Tag="TXT_KEY_HUMAN_DENOUNCE_SO_AI_DENOUNCE_1">
- 			<Text>Eu compartilho suas convicções de que {1_CivName} somente causa problemas para impérios civilizados do mundo. Talvez a combinação das nossas denúncias os ensine uma lição.</Text>
+			<Text>Eu compartilho suas convicções de que {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName} somente causa problemas para impérios civilizados do mundo. Talvez a combinação das nossas denúncias os ensine uma lição.</Text>
  		</Row>
  		<Row Tag="TXT_KEY_HUMAN_DOF_SO_AI_DENOUNCE_1">
- 			<Text>Ah, perfeito! Agora o verme está se procriando. Então, tenho que lidar com você e {1_CivName}? Vou ter que ensiná-los uma lição.</Text>
+			<Text>Ah, perfeito! Agora o verme está se procriando. Então, tenho que lidar com você e {1: gender *:noart?{}; feminine?{1: plural 2?as ; other?a ;}; masculine?{1: plural 2?os ; other?o ;}; other?{};}{1_CivName}? Vou ter que ensiná-los uma lição.</Text>
  		</Row>
  		<Row Tag="TXT_KEY_HUMAN_DENOUNCE_SO_AI_DOF_1">
- 			<Text>Qualquer um que mantenha distância de você certamente é digno de amizade. Dou meus cumprimentos a {1_CivName}.</Text>
+			<Text>Qualquer um que mantenha distância de você certamente é digno de amizade. Dou meus cumprimentos {1: gender *:noart?a; feminine?{1: plural 2?às; other?à;}; masculine?{1: plural 2?aos; other?ao;}; other?a;} {1_CivName}.</Text>
  		</Row>
  		<Row Tag="TXT_KEY_ALEXANDER_HOSTILE_AGGRESSIVE_MILITARY_WARNING_1">
  			<Text>Eu vejo o seu exército. Venha, deixe-me mostrar o que acontece quando alguém cruza as espadas com um grande general como eu.</Text>


### PR DESCRIPTION
Corrige vários problemas com artigos e pronomes:
- Muitas frases usavam apenas a forma indefinida ("de Rússia", "por Alemanha" -> "da Rússia", "pela Alemanha");
- Muitas frases não tinham a forma indefinida("da Viena", "pela Viena" -> "de Viena", "por Viena");
- Algumas frases usavam o indexador errado (1->2, 1->@1);