### PR TITLE
Corrige a tradução de Constable->Constábulário

### DIFF
--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Expansion.xml
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Expansion.xml
@@ -218,7 +218,7 @@
 			<Text>Reduz em 75% a perda de população em um ataque nuclear.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_CONSTABLE_STRATEGY">
-			<Text>A Guarda Policial diminui a taxa de roubo de tecnologias de sua cidade por espiões inimigos.</Text>
+			<Text>O Constabulário diminui a taxa de roubo de tecnologias de sua cidade por espiões inimigos.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_CONSTABLE_HELP">
 			<Text>Reduz em 25% a taxa de roubo por espiões.</Text>

--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Buildings_Expansion.xml
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Buildings_Expansion.xml
@@ -80,8 +80,8 @@
 			<Plurality>1|2</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_CONSTABLE">
-			<Text>Guarda Policial|Guardas Policiais</Text>
-			<Gender>feminine|feminine</Gender>
+			<Text>Constabulário|Constabulários</Text>
+			<Gender>masculine|masculine</Gender>
 			<Plurality>1|2</Plurality>			
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_POLICE_STATION">

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Inherited_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos2_Inherited_Expansion2.xml
@@ -163,7 +163,7 @@
 			<Text>Reduz em 75% a perda de população em um ataque nuclear.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_CONSTABLE_STRATEGY">
-			<Text>A Guarda Policial diminui a taxa de roubo de tecnologias de sua cidade por espiões inimigos.</Text>
+			<Text>O Constabulário diminui a taxa de roubo de tecnologias de sua cidade por espiões inimigos.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_CONSTABLE_HELP">
 			<Text>Reduz em 25% a taxa de roubo por espiões.</Text>

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Buildings_Inherited_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Buildings_Inherited_Expansion2.xml
@@ -107,8 +107,8 @@
             <Plurality>1|2</Plurality>
         </Row>
         <Row Tag="TXT_KEY_BUILDING_CONSTABLE">
-            <Text>Guarda Policial|Guardas Policiais</Text>
-            <Gender>feminine|feminine</Gender>
+            <Text>Constabulário|Constabulários</Text>
+            <Gender>masculine|masculine</Gender>
             <Plurality>1|2</Plurality>
         </Row>
         <Row Tag="TXT_KEY_BUILDING_POLICE_STATION">


### PR DESCRIPTION
A tradução atual, Guarda Policial, é equivocada.