### PR TITLE
Completa e padroniza a tradução de Cavalarias Mameluke e Mandekalu

### DIFF
--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Expansion.xml
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Expansion.xml
@@ -1331,7 +1331,7 @@
 			<Text>Modern Armor is just like its predecessor, the Tank, only more-so. Modern Armor is much stronger than the Tank unit and possesses all the Tank's abilities, such as moving after combat.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY_STRATEGY">
-			<Text>Essa é uma unidade exclusiva Songai, substituindo o {TXT_KEY_UNIT_KNIGHT}. Essa unidade tem as mesmas estatísticas que o {TXT_KEY_UNIT_KNIGHT}, mas é significativamente melhor atacando cidades. O {TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} pode se mover depois de atacar. Sua velocidade torna difícil para um inimigo montar uma linha de defesa antes de o {TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} atingir o alvo.</Text>
+			<Text>Essa é uma unidade exclusiva Songai, substituindo o {TXT_KEY_UNIT_KNIGHT}. Essa unidade tem as mesmas estatísticas que o {TXT_KEY_UNIT_KNIGHT}, mas é significativamente melhor ao atacar cidades. O {TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} pode se mover depois de atacar. Sua velocidade torna difícil para um inimigo montar uma linha de defesa antes de o {TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} atingir o alvo.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_TANK_STRATEGY">
 			<Text>The Tank is an extremely powerful and mobile land unit. It can move after combat, allowing it to blow holes in enemy lines and then move into the now-vacant hexes.</Text>

--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Medieval_Scenario.XML
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Medieval_Scenario.XML
@@ -380,10 +380,10 @@
 		</Row>
 		<!-- Unique units and buildings -->
 		<Row Tag="TXT_KEY_MEDIEVAL_SCENARIO_UNIT_HELP_MUSLIM_CAVALRY">
-			<Text>Poderosa Unidade Montada Medieval, fraca contra {TXT_KEY_UNIT_PIKEMAN[2]}. Apenas os Ayyubid podem treiná-la. Essa Unidade não é penalizada quando ataca Cidades, diferente do {TXT_KEY_UNIT_KNIGHT} que ela substitui.</Text>
+			<Text>Poderosa Unidade Montada Medieval, fraca contra {TXT_KEY_UNIT_PIKEMAN[2]}. Apenas os Aiúbidas podem treiná-la. Essa Unidade não é penalizada quando ataca Cidades, diferente do {TXT_KEY_UNIT_KNIGHT} que ela substitui.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_MEDIEVAL_SCENARIO_UNIT_SONGHAI_MUSLIMCAVALRY_STRATEGY">
-			<Text>Essa é uma unidade exclusiva Ayyubid, substituindo o {TXT_KEY_UNIT_KNIGHT}. Essa unidade tem as mesmas estatísticas que o {TXT_KEY_UNIT_KNIGHT}, mas é significativamente melhor atacando cidades. O Mameluke pode se mover depois de atacar. Sua velocidade torna difícil para um inimigo montar uma linha de defesa antes de o Mameluke atingir o alvo.</Text>
+			<Text>Essa é uma unidade exclusiva Aiúbida, substituindo o {TXT_KEY_UNIT_KNIGHT}. Essa unidade tem as mesmas estatísticas que o {TXT_KEY_UNIT_KNIGHT}, mas é significativamente melhor atacando cidades. A {TXT_KEY_MEDIEVAL_SCENARIO_UNIT_SONGHAI_MUSLIMCAVALRY} pode se mover depois de atacar. Sua velocidade torna difícil para um inimigo montar uma linha de defesa antes de a {TXT_KEY_MEDIEVAL_SCENARIO_UNIT_SONGHAI_MUSLIMCAVALRY} atingir o alvo.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_WELSH_LONGBOWMAN_STRATEGY">
 			<Text>The Welsh Longbowman is a Celtic unique unit, replacing the Crossbowman. The Welsh Longbowman has a greater range than the Crossbowman, allowing it to attack enemies three hexes away, often destroying them before they can strike back. Like other ranged units, it is vulnerable to melee attack.</Text>

--- a/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Units_Scenarios_Expansion.xml
+++ b/Assets/DLC/Expansion/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Units_Scenarios_Expansion.xml
@@ -70,8 +70,8 @@
 		</Row>
 		<!-- INTO THE RENAISSANCE -->
 		<Row Tag="TXT_KEY_MEDIEVAL_SCENARIO_UNIT_SONGHAI_MUSLIMCAVALRY">
-			<Text>Mameluke|Mamelukes</Text>
-			<Gender>masculine:human</Gender>
+			<Text>Cavalaria Mamluke|Cavalarias Mamluke</Text>
+			<Gender>feminine:human</Gender>
 			<Plurality>1|2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_WELSH_LONGBOWMAN">

--- a/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Inherited_Expansion2.xml
+++ b/Assets/DLC/Expansion2/Gameplay/XML/Text/pt_BR/CIV5GameTextInfos_Civilopedia_Inherited_Expansion2.xml
@@ -287,7 +287,7 @@
 			<Text>Modern Armor is just like its predecessor, the Tank, only more-so. Modern Armor is much stronger than the Tank unit and possesses all the Tank's abilities, such as moving after combat.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY_STRATEGY">
-			<Text>Essa é uma unidade exclusiva Songai, substituindo o {TXT_KEY_UNIT_KNIGHT}. Essa unidade tem as mesmas estatísticas que o {TXT_KEY_UNIT_KNIGHT}, mas é significativamente melhor atacando cidades. O {TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} pode se mover depois de atacar. Sua velocidade torna difícil para um inimigo montar uma linha de defesa antes de o {TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} atingir o alvo.</Text>
+			<Text>Essa é uma unidade exclusiva Songai, substituindo o {TXT_KEY_UNIT_KNIGHT}. Essa unidade tem as mesmas estatísticas que o {TXT_KEY_UNIT_KNIGHT}, mas é significativamente melhor ao atacar cidades. O {TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} pode se mover depois de atacar. Sua velocidade torna difícil para um inimigo montar uma linha de defesa antes de o {TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} atingir o alvo.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_TANK_STRATEGY">
 			<Text>The Tank is an extremely powerful and mobile land unit. It can move after combat, allowing it to blow holes in enemy lines and then move into the now-vacant hexes.</Text>

--- a/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_Civilopedia.xml
+++ b/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_Civilopedia.xml
@@ -6541,7 +6541,7 @@
 			<Text>{TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} (Songai)</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CIVILOPEDIA_UNITS_MEDIEVAL_MUSLIMCAVALRY_TEXT">
-			<Text>Como seus equivalentes do Norte, os exércitos Muçulmanos também continham unidades de cavalaria pesada, semelhante em forma e função aos {TXT_KEY_UNIT_KNIGHT} Europeus. Como os Europeus, os cavaleiros Muçulmanos também eram da parte mais alta da sociedade, possuindo as melhores armas, armaduras e cavalos. A armadura podia ser modificada para refletir as diferenças no clima - mesmo o mais nobre cavaleiro seria rapidamente assado, se vestisse a armadura em um verão do Oriente Médio - mas ainda assim dava-lhes uma grande vantagem sobre as outras unidades no campo de batalha. Relatos históricos admitem que cavaleiros Muçulmanos eram geralmente páreos para os seus adversários Europeus.</Text>
+			<Text>Como seus equivalentes do Norte, os exércitos Muçulmanos também continham unidades de cavalaria pesada, semelhante em forma e função aos {TXT_KEY_UNIT_KNIGHT[2]} Europeus. Como os Europeus, os cavaleiros Muçulmanos também eram da parte mais alta da sociedade, possuindo as melhores armas, armaduras e cavalos. A armadura podia ser modificada para refletir as diferenças no clima - mesmo o mais nobre cavaleiro seria rapidamente assado, se vestisse a armadura em um verão do Oriente Médio - mas ainda assim dava-lhes uma grande vantagem sobre as outras unidades no campo de batalha. Relatos históricos admitem que cavaleiros Muçulmanos eram geralmente páreos para os seus adversários Europeus.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CIVILOPEDIA_UNITS_MEDIEVAL_PIKEMAN_HEADING">
 			<Text>{TXT_KEY_UNIT_PIKEMAN}</Text>
@@ -10678,7 +10678,7 @@
 			<Text>Esta é a unidade siamesa exclusiva, que substitui o {TXT_KEY_UNIT_KNIGHT}. O {TXT_KEY_UNIT_SIAMESE_WARELEPHANT} é mais lento que o {TXT_KEY_UNIT_KNIGHT} mais é mais poderoso. Assim como o {TXT_KEY_UNIT_KNIGHT}, é capaz de se mover após atacar. Equipado com lanças, o {TXT_KEY_UNIT_SIAMESE_WARELEPHANT} ganha um bônus de combate significativo quando ataca outras unidades montadas.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY_STRATEGY">
-			<Text>Esta é a unidade songai exclusiva, que substitui o {TXT_KEY_UNIT_KNIGHT}. Possui as mesmas características do {TXT_KEY_UNIT_KNIGHT}, mas ganha um significativo bônus quando ataca cidades. A {TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} pode se mover após atacar. Sua velocidade o torna uma unidade difícil para que o inimigo possa construir uma linha defensiva antes que ele alcance ao alvo.</Text>
+			<Text>Esta é a unidade Songai exclusiva, que substitui o {TXT_KEY_UNIT_KNIGHT}. Possui as mesmas características do {TXT_KEY_UNIT_KNIGHT}, mas ganha um significativo bônus quando ataca cidades. A {TXT_KEY_UNIT_SONGHAI_MUSLIMCAVALRY} pode se mover após atacar. Sua velocidade o torna uma unidade difícil para que o inimigo possa construir uma linha defensiva antes que ele alcance ao alvo.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_SPEARMAN_STRATEGY">
 			<Text>O {TXT_KEY_UNIT_SPEARMAN} é a primeira unidade de ataque à distância disponível depois do Guerreiro. Ela é um pouco mais poderosa que o Guerreiro, entretanto, recebe um bônus significativo contra unidades montadas ({TXT_KEY_UNIT_CHARIOT_ARCHER}, {TXT_KEY_UNIT_HORSEMAN} e similares).</Text>


### PR DESCRIPTION
Tradução da civilopédia, corrige referências e padroniza a tradução de Cavalarias Mameluke e Mandekalu.