### PR TITLE
Desfaz a confusão entre Spearman, Pikeman e Lancer

### DIFF
--- a/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_Units.xml
+++ b/Assets/Gameplay/XML/NewText/PT_BR/CIV5GameTextInfos_Units.xml
@@ -257,7 +257,7 @@
 			<Plurality>1|2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_LANCER">
-			<Text>Lanceiro|Lanceiros</Text>
+			<Text>Lanceiro Montado|Lanceiros Montados</Text>
 			<Gender>masculine:human</Gender>
 			<Plurality>1|2</Plurality>
 		</Row>
@@ -377,7 +377,7 @@
 			<Plurality>1|2</Plurality>
 		</Row>
 		<Row Tag="TXT_KEY_UNIT_SPEARMAN">
-			<Text>Guerreiro com Lança|Guerreiros com Lança</Text>
+			<Text>Lanceiro|Lanceiros</Text>
 			<Gender>masculine:human</Gender>
 			<Plurality>1|2</Plurality>
 		</Row>


### PR DESCRIPTION
- Spearman e Lancer estavam traduzidos para Lanceiro, o segundo agora é Lanceiro Montado;
- As referências a `{SPEARMAN}` e `{PIKEMAN}` tinham sido mudadas para `{LANCER}` na tradução, voltei para o original;
- Tradução de algumas descrições pendentes na Civilopédia;

Fixes #34